### PR TITLE
fix(codegen): emit valid WASM and correct collection runtime

### DIFF
--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -1,6 +1,13 @@
 use crate::ir::IRType;
 use std::collections::HashMap;
 
+/// Number of scratch/temporary locals reserved for intermediate calculations
+/// (pointer/index bookkeeping, search loops, type coercion, ...). Reserved
+/// per-function in `compile_function` after params and named locals, so these
+/// indices never alias real variables. Keep this >= the largest `temp_local + N`
+/// offset emitted anywhere in the compiler.
+pub const SCRATCH_LOCALS: u32 = 8;
+
 /// Local variable
 pub struct LocalInfo {
     pub index: u32,
@@ -36,19 +43,15 @@ pub struct CompilationContext {
 impl CompilationContext {
     /// Create a new compilation context
     pub fn new() -> Self {
-        let mut ctx = CompilationContext {
+        // Scratch locals are reserved per-function in `compile_function` (after
+        // params and named locals are allocated), so nothing is reserved here.
+        CompilationContext {
             locals_map: HashMap::new(),
             local_count: 0,
             function_map: HashMap::new(),
             class_map: HashMap::new(),
             temp_local: 0,
-        };
-
-        // Add temporary locals for calculations
-        ctx.temp_local = ctx.local_count;
-        ctx.local_count += 3;
-
-        ctx
+        }
     }
 
     /// Add a local variable to the context

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -8,6 +8,16 @@ fn f64_const(value: f64) -> wasm_encoder::Ieee64 {
     value.into()
 }
 
+/// Collections store one i32 word per element, but strings and bytes leave two
+/// values on the stack (offset, length). After emitting such an element, drop
+/// the length so only the offset remains; identical string literals are
+/// interned to the same offset, so offset comparison preserves value equality.
+fn narrow_element_to_word(func: &mut Function, elem_type: &IRType) {
+    if matches!(elem_type, IRType::String | IRType::Bytes) {
+        func.instruction(&Instruction::Drop);
+    }
+}
+
 /// Emit WebAssembly instructions for an IR expression
 pub fn emit_expr(
     expr: &IRExpr,
@@ -467,6 +477,91 @@ pub fn emit_expr(
             }
         }
         IRExpr::CompareOp { left, right, op } => {
+            // Membership tests (`in` / `not in`) search a container rather than
+            // comparing two scalars, so they are handled before the numeric
+            // comparison logic below.
+            if matches!(op, IRCompareOp::In | IRCompareOp::NotIn) {
+                let elem_type = emit_expr(left, func, ctx, memory_layout, None);
+                // Reduce the searched element to a single word (matching how
+                // collection elements are stored) before emitting the container.
+                narrow_element_to_word(func, &elem_type);
+                let container_type = emit_expr(right, func, ctx, memory_layout, None);
+
+                // Sets and lists share the [count:i32][elem0:i32]... layout with
+                // 4-byte elements, so a linear scan works for both. Float
+                // elements (stored as f64) and other containers fall back to a
+                // conservative constant result.
+                let searchable = matches!(container_type, IRType::Set(_) | IRType::List(_))
+                    && elem_type != IRType::Float;
+
+                if !searchable {
+                    func.instruction(&Instruction::Drop); // container pointer
+                    func.instruction(&Instruction::Drop); // element
+                    func.instruction(&Instruction::I32Const(i32::from(matches!(
+                        op,
+                        IRCompareOp::NotIn
+                    ))));
+                    return IRType::Bool;
+                }
+
+                // Stack: (element, container_ptr).
+                func.instruction(&Instruction::LocalSet(ctx.temp_local)); // container_ptr
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 1)); // element
+
+                // count = load(container_ptr)
+                func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                func.instruction(&Instruction::I32Load(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 2)); // count
+                func.instruction(&Instruction::I32Const(0));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 3)); // counter
+                func.instruction(&Instruction::I32Const(0));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 4)); // found
+
+                func.instruction(&Instruction::Block(BlockType::Empty));
+                func.instruction(&Instruction::Loop(BlockType::Empty));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
+                func.instruction(&Instruction::I32GeS);
+                func.instruction(&Instruction::BrIf(1));
+                // existing = load(container_ptr + 4 + counter*4)
+                func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                func.instruction(&Instruction::I32Const(4));
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                func.instruction(&Instruction::I32Const(4));
+                func.instruction(&Instruction::I32Mul);
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::I32Load(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
+                func.instruction(&Instruction::I32Eq);
+                func.instruction(&Instruction::If(BlockType::Empty));
+                func.instruction(&Instruction::I32Const(1));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 4)); // found = 1
+                func.instruction(&Instruction::Br(2));
+                func.instruction(&Instruction::End);
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                func.instruction(&Instruction::I32Const(1));
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 3));
+                func.instruction(&Instruction::Br(0));
+                func.instruction(&Instruction::End); // loop
+                func.instruction(&Instruction::End); // block
+
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                if matches!(op, IRCompareOp::NotIn) {
+                    func.instruction(&Instruction::I32Eqz);
+                }
+                return IRType::Bool;
+            }
+
             let left_type = emit_expr(left, func, ctx, memory_layout, None);
             let right_type = emit_expr(right, func, ctx, memory_layout, Some(&left_type));
 
@@ -628,22 +723,17 @@ pub fn emit_expr(
                             return IRType::Unknown;
                         }
                         match &arg_types[0] {
-                            IRType::String => {
-                                // String is (offset, length) on stack; pop offset, keep length
+                            IRType::String | IRType::Bytes => {
+                                // (offset, length) on stack; pop offset, keep length
                                 func.instruction(&Instruction::Drop);
                                 IRType::Int
                             }
-                            IRType::List(_) => {
-                                // List is a pointer; load length from first 4 bytes
-                                func.instruction(&Instruction::I32Load(MemArg {
-                                    offset: 0,
-                                    align: 2,
-                                    memory_index: 0,
-                                }));
-                                IRType::Int
-                            }
-                            IRType::Dict(_, _) => {
-                                // Dict is a pointer; load length from first 4 bytes
+                            // Lists, dicts, sets and tuples are all pointers that
+                            // store their element/entry count in the first 4 bytes.
+                            IRType::List(_)
+                            | IRType::Dict(_, _)
+                            | IRType::Set(_)
+                            | IRType::Tuple(_) => {
                                 func.instruction(&Instruction::I32Load(MemArg {
                                     offset: 0,
                                     align: 2,
@@ -814,28 +904,20 @@ pub fn emit_expr(
                 memory_index: 0,
             }));
 
-            // Determine element type from first element
-            let elem_type = if !elements.is_empty() {
-                emit_expr(&elements[0], func, ctx, memory_layout, None)
-            } else {
-                IRType::Unknown
-            };
-
-            // Store each element
+            // Store each element. A WASM store pops the value first, then the
+            // address, so the destination address must be pushed *before* the
+            // value. list_ptr and the slot offset are compile-time constants,
+            // so we fold them into a single address constant.
+            let mut elem_type = IRType::Unknown;
             for (i, elem) in elements.iter().enumerate() {
-                let offset = 4 + (i as u32 * 4); // Skip length field
+                let addr = list_ptr + 4 + (i as u32 * 4); // Skip length field
 
-                // Get the element value
-                let elem_type = emit_expr(elem, func, ctx, memory_layout, None);
+                func.instruction(&Instruction::I32Const(addr as i32));
+                let ty = emit_expr(elem, func, ctx, memory_layout, None);
+                narrow_element_to_word(func, &ty);
 
-                // Store based on element type
-                match elem_type {
+                match ty {
                     IRType::Float => {
-                        func.instruction(&Instruction::I32Const(list_ptr as i32));
-                        func.instruction(&Instruction::I32Const(offset as i32));
-                        func.instruction(&Instruction::I32Add);
-                        // Value is already on stack, but we need it as f64
-                        // TODO: Handle type conversion properly
                         func.instruction(&Instruction::F64Store(MemArg {
                             offset: 0,
                             align: 3,
@@ -843,16 +925,16 @@ pub fn emit_expr(
                         }));
                     }
                     _ => {
-                        func.instruction(&Instruction::I32Const(list_ptr as i32));
-                        func.instruction(&Instruction::I32Const(offset as i32));
-                        func.instruction(&Instruction::I32Add);
-                        // Value is already on stack
                         func.instruction(&Instruction::I32Store(MemArg {
                             offset: 0,
                             align: 2,
                             memory_index: 0,
                         }));
                     }
+                }
+
+                if i == 0 {
+                    elem_type = ty;
                 }
             }
 
@@ -862,64 +944,119 @@ pub fn emit_expr(
         }
         IRExpr::SetLiteral(elements) => {
             // Set layout in memory: [num_elements:i32][elem0:i32][elem1:i32]...
-            // Similar to list but for sets (elements stored sequentially)
-            // Allocate after lists (at offset 20000+)
+            // A set drops duplicate elements, so the stored count is computed at
+            // runtime as elements are inserted (it may be smaller than the
+            // number of literal elements).
 
+            // Empty set: store a count of 0 so membership tests read a valid header.
             if elements.is_empty() {
-                // Empty set: just a length of 0
-                func.instruction(&Instruction::I32Const(20000)); // Pointer to empty set
+                func.instruction(&Instruction::I32Const(20000));
+                func.instruction(&Instruction::I32Const(0));
+                func.instruction(&Instruction::I32Store(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::I32Const(20000));
                 return IRType::Set(Box::new(IRType::Unknown));
             }
 
-            // Use a fixed allocation address for simplicity
+            // Use a fixed allocation address for simplicity.
             let set_ptr = 20000 + (ctx.local_count * 100);
 
-            // Store number of elements at the beginning
+            // Start with an empty set (count = 0).
             func.instruction(&Instruction::I32Const(set_ptr as i32));
-            func.instruction(&Instruction::I32Const(elements.len() as i32));
+            func.instruction(&Instruction::I32Const(0));
             func.instruction(&Instruction::I32Store(MemArg {
                 offset: 0,
                 align: 2,
                 memory_index: 0,
             }));
 
-            // Determine element type from first element
-            let elem_type = if !elements.is_empty() {
-                emit_expr(&elements[0], func, ctx, memory_layout, None)
-            } else {
-                IRType::Unknown
-            };
-
-            // Store each element
+            let mut elem_type = IRType::Unknown;
             for (i, elem) in elements.iter().enumerate() {
-                let offset = 4 + (i as u32 * 4); // Skip element count field
-
-                // Get the element value
-                let elem_type = emit_expr(elem, func, ctx, memory_layout, None);
-
-                // Store based on element type
-                match elem_type {
-                    IRType::Float => {
-                        func.instruction(&Instruction::I32Const(set_ptr as i32));
-                        func.instruction(&Instruction::I32Const(offset as i32));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::F64Store(MemArg {
-                            offset: 0,
-                            align: 3,
-                            memory_index: 0,
-                        }));
-                    }
-                    _ => {
-                        func.instruction(&Instruction::I32Const(set_ptr as i32));
-                        func.instruction(&Instruction::I32Const(offset as i32));
-                        func.instruction(&Instruction::I32Add);
-                        func.instruction(&Instruction::I32Store(MemArg {
-                            offset: 0,
-                            align: 2,
-                            memory_index: 0,
-                        }));
-                    }
+                // Evaluate the element first (this may use scratch locals), then
+                // stash it before running the dedup search.
+                let ty = emit_expr(elem, func, ctx, memory_layout, None);
+                narrow_element_to_word(func, &ty);
+                if i == 0 {
+                    elem_type = ty;
                 }
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 1)); // element
+
+                // count = load(set_ptr)
+                func.instruction(&Instruction::I32Const(set_ptr as i32));
+                func.instruction(&Instruction::I32Load(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 2)); // count
+                func.instruction(&Instruction::I32Const(0));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 3)); // counter
+                func.instruction(&Instruction::I32Const(0));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 4)); // found
+
+                // Search the existing elements for a duplicate.
+                func.instruction(&Instruction::Block(BlockType::Empty));
+                func.instruction(&Instruction::Loop(BlockType::Empty));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
+                func.instruction(&Instruction::I32GeS);
+                func.instruction(&Instruction::BrIf(1));
+                // existing = load(set_ptr + 4 + counter*4)
+                func.instruction(&Instruction::I32Const((set_ptr + 4) as i32));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                func.instruction(&Instruction::I32Const(4));
+                func.instruction(&Instruction::I32Mul);
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::I32Load(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
+                func.instruction(&Instruction::I32Eq);
+                func.instruction(&Instruction::If(BlockType::Empty));
+                func.instruction(&Instruction::I32Const(1));
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 4)); // found = 1
+                func.instruction(&Instruction::Br(2));
+                func.instruction(&Instruction::End);
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                func.instruction(&Instruction::I32Const(1));
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalSet(ctx.temp_local + 3));
+                func.instruction(&Instruction::Br(0));
+                func.instruction(&Instruction::End); // loop
+                func.instruction(&Instruction::End); // block
+
+                // If not already present, append at slot `count` and bump count.
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                func.instruction(&Instruction::I32Eqz);
+                func.instruction(&Instruction::If(BlockType::Empty));
+                // address = set_ptr + 4 + count*4
+                func.instruction(&Instruction::I32Const((set_ptr + 4) as i32));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
+                func.instruction(&Instruction::I32Const(4));
+                func.instruction(&Instruction::I32Mul);
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 1)); // element
+                func.instruction(&Instruction::I32Store(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                // count += 1
+                func.instruction(&Instruction::I32Const(set_ptr as i32));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
+                func.instruction(&Instruction::I32Const(1));
+                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::I32Store(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::End);
             }
 
             // Return pointer to the set
@@ -949,18 +1086,18 @@ pub fn emit_expr(
             // Track element types for heterogeneous tuples
             let mut element_types = Vec::new();
 
-            // Store each element
+            // Store each element. The destination address is pushed before the
+            // value (WASM stores pop the value first, then the address).
             for (i, elem) in elements.iter().enumerate() {
-                let offset = 4 + (i as u32 * 4);
+                let addr = tuple_ptr + 4 + (i as u32 * 4);
 
+                func.instruction(&Instruction::I32Const(addr as i32));
                 let elem_type = emit_expr(elem, func, ctx, memory_layout, None);
+                narrow_element_to_word(func, &elem_type);
                 element_types.push(elem_type.clone());
 
                 match elem_type {
                     IRType::Float => {
-                        func.instruction(&Instruction::I32Const(tuple_ptr as i32));
-                        func.instruction(&Instruction::I32Const(offset as i32));
-                        func.instruction(&Instruction::I32Add);
                         func.instruction(&Instruction::F64Store(MemArg {
                             offset: 0,
                             align: 3,
@@ -968,9 +1105,6 @@ pub fn emit_expr(
                         }));
                     }
                     _ => {
-                        func.instruction(&Instruction::I32Const(tuple_ptr as i32));
-                        func.instruction(&Instruction::I32Const(offset as i32));
-                        func.instruction(&Instruction::I32Add);
                         func.instruction(&Instruction::I32Store(MemArg {
                             offset: 0,
                             align: 2,
@@ -1009,16 +1143,16 @@ pub fn emit_expr(
                 (IRType::Unknown, IRType::Unknown)
             };
 
-            // Store each key-value pair
+            // Store each key-value pair. The destination address is pushed
+            // before the value (WASM stores pop the value first, then address).
             for (i, (key_expr, val_expr)) in pairs.iter().enumerate() {
-                let key_offset = 4 + (i as u32 * 8); // 4 bytes for length + i * 8 (key + value)
-                let val_offset = 8 + (i as u32 * 8);
+                let key_addr = dict_ptr + 4 + (i as u32 * 8); // length + i*8 (key + value)
+                let val_addr = dict_ptr + 8 + (i as u32 * 8);
 
                 // Store key
-                emit_expr(key_expr, func, ctx, memory_layout, None);
-                func.instruction(&Instruction::I32Const(dict_ptr as i32));
-                func.instruction(&Instruction::I32Const(key_offset as i32));
-                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::I32Const(key_addr as i32));
+                let k_type = emit_expr(key_expr, func, ctx, memory_layout, None);
+                narrow_element_to_word(func, &k_type);
                 func.instruction(&Instruction::I32Store(MemArg {
                     offset: 0,
                     align: 2,
@@ -1026,10 +1160,9 @@ pub fn emit_expr(
                 }));
 
                 // Store value
-                emit_expr(val_expr, func, ctx, memory_layout, None);
-                func.instruction(&Instruction::I32Const(dict_ptr as i32));
-                func.instruction(&Instruction::I32Const(val_offset as i32));
-                func.instruction(&Instruction::I32Add);
+                func.instruction(&Instruction::I32Const(val_addr as i32));
+                let v_type = emit_expr(val_expr, func, ctx, memory_layout, None);
+                narrow_element_to_word(func, &v_type);
                 func.instruction(&Instruction::I32Store(MemArg {
                     offset: 0,
                     align: 2,
@@ -1048,35 +1181,27 @@ pub fn emit_expr(
 
             match container_type {
                 IRType::String => {
-                    // String indexing returns a single character string
-                    // Stack: (offset, length, index)
-                    // Result: (char_offset, 1) - single character at the index
-
-                    // Drop the length, keep offset and index
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local));
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32Add);
-                    // Now we have the offset of the character
-                    // Length is always 1 for a single character
+                    // String indexing returns a single character string.
+                    // Stack: (offset, length, index) -> result (char_offset, 1)
+                    func.instruction(&Instruction::LocalSet(ctx.temp_local)); // index
+                    func.instruction(&Instruction::Drop); // discard length
+                                                          // Stack: (offset)
+                    func.instruction(&Instruction::LocalGet(ctx.temp_local)); // index
+                    func.instruction(&Instruction::I32Add); // offset + index
+                                                            // Length is always 1 for a single character
                     func.instruction(&Instruction::I32Const(1));
 
                     IRType::String
                 }
                 IRType::Bytes => {
-                    // Bytes indexing returns an integer (byte value 0-255)
-                    // Stack: (offset, length, index)
-                    // Result: integer value at that position
-
-                    // Save offset
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local + 1));
-                    // Drop length, keep offset and index
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local));
-                    // Restore offset
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
-                    // Add index to offset to get memory address
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32Add);
-                    // Load unsigned byte (0-255)
+                    // Bytes indexing returns an integer (byte value 0-255).
+                    // Stack: (offset, length, index) -> result (byte)
+                    func.instruction(&Instruction::LocalSet(ctx.temp_local)); // index
+                    func.instruction(&Instruction::Drop); // discard length
+                                                          // Stack: (offset)
+                    func.instruction(&Instruction::LocalGet(ctx.temp_local)); // index
+                    func.instruction(&Instruction::I32Add); // offset + index
+                                                            // Load unsigned byte (0-255)
                     func.instruction(&Instruction::I32Load8U(MemArg {
                         offset: 0,
                         align: 0,
@@ -1087,20 +1212,15 @@ pub fn emit_expr(
                 }
                 IRType::List(element_type) => {
                     // List indexing: list is stored as [length:i32][elem0:i32][elem1:i32]...
-                    // We have: list_ptr on stack, index on stack
-                    // Calculate address: list_ptr + 4 + (index * 4)
-
-                    // Save list pointer
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local));
-                    // index is still on stack, multiply by 4
+                    // Stack: (list_ptr, index). Address = list_ptr + 4 + index*4.
+                    func.instruction(&Instruction::LocalSet(ctx.temp_local)); // index
+                                                                              // Stack: (list_ptr)
+                    func.instruction(&Instruction::LocalGet(ctx.temp_local)); // index
                     func.instruction(&Instruction::I32Const(4));
-                    func.instruction(&Instruction::I32Mul);
-                    // Add 4 to skip the length field
+                    func.instruction(&Instruction::I32Mul); // index * 4
                     func.instruction(&Instruction::I32Const(4));
-                    func.instruction(&Instruction::I32Add);
-                    // Restore list pointer and add
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::I32Add); // index*4 + 4
+                    func.instruction(&Instruction::I32Add); // list_ptr + index*4 + 4
 
                     // Load the element based on element type
                     match element_type.as_ref() {
@@ -1125,9 +1245,9 @@ pub fn emit_expr(
                 IRType::Dict(_key_type, value_type) => {
                     // Dictionary indexing using linear search
                     // Dict layout: [num_entries:i32][key0:i32][val0:i32][key1:i32][val1:i32]...
-                    // Save dict pointer and key
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local)); // dict_ptr
+                    // Stack: (dict_ptr, search_key) with search_key on top.
                     func.instruction(&Instruction::LocalSet(ctx.temp_local + 1)); // search_key
+                    func.instruction(&Instruction::LocalSet(ctx.temp_local)); // dict_ptr
 
                     // Load the number of entries
                     func.instruction(&Instruction::LocalGet(ctx.temp_local));
@@ -1138,9 +1258,13 @@ pub fn emit_expr(
                     }));
                     func.instruction(&Instruction::LocalSet(ctx.temp_local + 2)); // num_entries
 
-                    // Initialize counter to 0
+                    // Initialize counter and result (result defaults to 0 when
+                    // the key is absent). Using a result local avoids leaving a
+                    // stray value on the stack on the found path.
                     func.instruction(&Instruction::I32Const(0));
                     func.instruction(&Instruction::LocalSet(ctx.temp_local + 3)); // counter
+                    func.instruction(&Instruction::I32Const(0));
+                    func.instruction(&Instruction::LocalSet(ctx.temp_local + 4)); // result
 
                     // Loop: while counter < num_entries
                     func.instruction(&Instruction::Block(BlockType::Empty));
@@ -1171,7 +1295,7 @@ pub fn emit_expr(
                     func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
                     func.instruction(&Instruction::I32Eq);
 
-                    // If equal, load and return value
+                    // If equal, capture the value and break out of the loop
                     func.instruction(&Instruction::If(BlockType::Empty));
                     // Load value at offset: dict_ptr + 4 + (counter * 8) + 4
                     func.instruction(&Instruction::LocalGet(ctx.temp_local));
@@ -1180,12 +1304,14 @@ pub fn emit_expr(
                     func.instruction(&Instruction::I32Mul);
                     func.instruction(&Instruction::I32Const(8));
                     func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::I32Add);
                     func.instruction(&Instruction::I32Load(MemArg {
                         offset: 0,
                         align: 2,
                         memory_index: 0,
                     }));
-                    func.instruction(&Instruction::Br(2)); // Break out of loop with value
+                    func.instruction(&Instruction::LocalSet(ctx.temp_local + 4)); // result
+                    func.instruction(&Instruction::Br(2)); // Break out of the loop
                     func.instruction(&Instruction::End);
 
                     // Increment counter
@@ -1198,25 +1324,22 @@ pub fn emit_expr(
                     func.instruction(&Instruction::End);
                     func.instruction(&Instruction::End);
 
-                    // Not found: return default value 0
-                    func.instruction(&Instruction::I32Const(0));
+                    // Push the looked-up value (0 if the key was not found)
+                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
 
                     value_type.as_ref().clone()
                 }
                 IRType::Tuple(element_types) => {
                     // Tuple indexing: tuple is stored as [length:i32][elem0:i32][elem1:i32]...
-                    // Index must be a constant or we compute dynamically
-                    // Save tuple pointer
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local));
-                    // index is still on stack, multiply by 4
+                    // Stack: (tuple_ptr, index). Address = tuple_ptr + 4 + index*4.
+                    func.instruction(&Instruction::LocalSet(ctx.temp_local)); // index
+                                                                              // Stack: (tuple_ptr)
+                    func.instruction(&Instruction::LocalGet(ctx.temp_local)); // index
                     func.instruction(&Instruction::I32Const(4));
-                    func.instruction(&Instruction::I32Mul);
-                    // Add 4 to skip the length field
+                    func.instruction(&Instruction::I32Mul); // index * 4
                     func.instruction(&Instruction::I32Const(4));
-                    func.instruction(&Instruction::I32Add);
-                    // Restore tuple pointer and add
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::I32Add); // index*4 + 4
+                    func.instruction(&Instruction::I32Add); // tuple_ptr + index*4 + 4
 
                     // For homogeneous indexing, use first element type
                     // In practice, we'd need to track which index is being accessed

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -1,4 +1,4 @@
-use crate::compiler::context::CompilationContext;
+use crate::compiler::context::{CompilationContext, SCRATCH_LOCALS};
 use crate::compiler::expression::{emit_expr, emit_integer_power_operation};
 use crate::ir::{IRBody, IRFunction, IROp, IRStatement, IRType, MemoryLayout};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
@@ -18,6 +18,13 @@ pub fn compile_function(
 
     // Scan for variable declarations to allocate locals
     scan_and_allocate_locals(&ir_func.body, ctx);
+
+    // Reserve scratch locals after all params and named locals so temporary
+    // calculations never clobber real variables. These indices are declared as
+    // i32 locals by the type-counting loop below (they are absent from
+    // locals_map, so get_local_type_by_index defaults them to i32).
+    ctx.temp_local = ctx.local_count;
+    ctx.local_count += SCRATCH_LOCALS;
 
     // Determine local types for WebAssembly
     let mut locals = Vec::new();
@@ -298,8 +305,9 @@ pub fn compile_body(
                 func.instruction(&Instruction::Block(BlockType::Empty));
                 func.instruction(&Instruction::Loop(BlockType::Empty));
 
-                // Condition check
+                // Condition check: exit the loop when the condition is false.
                 emit_expr(condition, func, ctx, memory_layout, Some(&IRType::Bool));
+                func.instruction(&Instruction::I32Eqz);
                 func.instruction(&Instruction::BrIf(1));
 
                 // Loop body
@@ -840,17 +848,130 @@ pub fn compile_body(
                         }
                     }
                     IRType::Dict(_key_type, _value_type) => {
-                        // Dictionary assignment (linear search and update)
-                        // For now, just store at a fixed offset after the entries
-                        // TODO: Implement proper hash table or linear probe storage
-                        func.instruction(&Instruction::LocalGet(ctx.temp_local)); // dict_ptr
-                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 1)); // key
-                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 2)); // value
+                        // Dictionary assignment via linear search.
+                        // Layout: [num_entries:i32][key0][val0][key1][val1]...
+                        //   temp_local     = dict_ptr
+                        //   temp_local + 1 = key
+                        //   temp_local + 2 = value
+                        //   temp_local + 3 = num_entries
+                        //   temp_local + 4 = counter
+                        //   temp_local + 5 = found flag (0/1)
 
-                        // Just drop the values for now - proper implementation would search/update
-                        func.instruction(&Instruction::Drop);
-                        func.instruction(&Instruction::Drop);
-                        func.instruction(&Instruction::Drop);
+                        // num_entries = load(dict_ptr)
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::I32Load(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+                        func.instruction(&Instruction::LocalSet(ctx.temp_local + 3));
+
+                        // counter = 0; found = 0
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::LocalSet(ctx.temp_local + 4));
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::LocalSet(ctx.temp_local + 5));
+
+                        // Search for an existing entry with a matching key.
+                        func.instruction(&Instruction::Block(BlockType::Empty));
+                        func.instruction(&Instruction::Loop(BlockType::Empty));
+
+                        // if counter >= num_entries: break
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                        func.instruction(&Instruction::I32GeS);
+                        func.instruction(&Instruction::BrIf(1));
+
+                        // key_at = load(dict_ptr + counter*8 + 4)
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                        func.instruction(&Instruction::I32Const(8));
+                        func.instruction(&Instruction::I32Mul);
+                        func.instruction(&Instruction::I32Const(4));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Load(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+
+                        // if key_at == key: update value and break
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
+                        func.instruction(&Instruction::I32Eq);
+                        func.instruction(&Instruction::If(BlockType::Empty));
+                        // address = dict_ptr + counter*8 + 8
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                        func.instruction(&Instruction::I32Const(8));
+                        func.instruction(&Instruction::I32Mul);
+                        func.instruction(&Instruction::I32Const(8));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 2)); // value
+                        func.instruction(&Instruction::I32Store(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+                        func.instruction(&Instruction::I32Const(1));
+                        func.instruction(&Instruction::LocalSet(ctx.temp_local + 5)); // found = 1
+                        func.instruction(&Instruction::Br(2)); // exit the loop
+                        func.instruction(&Instruction::End);
+
+                        // counter += 1; continue
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                        func.instruction(&Instruction::I32Const(1));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalSet(ctx.temp_local + 4));
+                        func.instruction(&Instruction::Br(0));
+                        func.instruction(&Instruction::End); // loop
+                        func.instruction(&Instruction::End); // block
+
+                        // If the key was not present, append a new entry at slot
+                        // num_entries and bump the entry count.
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 5));
+                        func.instruction(&Instruction::I32Eqz);
+                        func.instruction(&Instruction::If(BlockType::Empty));
+                        // store key at dict_ptr + num_entries*8 + 4
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                        func.instruction(&Instruction::I32Const(8));
+                        func.instruction(&Instruction::I32Mul);
+                        func.instruction(&Instruction::I32Const(4));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 1)); // key
+                        func.instruction(&Instruction::I32Store(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+                        // store value at dict_ptr + num_entries*8 + 8
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                        func.instruction(&Instruction::I32Const(8));
+                        func.instruction(&Instruction::I32Mul);
+                        func.instruction(&Instruction::I32Const(8));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 2)); // value
+                        func.instruction(&Instruction::I32Store(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+                        // num_entries += 1; store back to dict_ptr
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                        func.instruction(&Instruction::I32Const(1));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Store(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+                        func.instruction(&Instruction::End);
                     }
                     IRType::String => {
                         // String indexing is read-only in Python, assignment not directly supported

--- a/src/compiler/module.rs
+++ b/src/compiler/module.rs
@@ -1,6 +1,6 @@
 use crate::compiler::context::{ClassInfo, CompilationContext};
 use crate::compiler::function::compile_function;
-use crate::ir::{IRModule, IRType, MemoryLayout};
+use crate::ir::{IRModule, IRType};
 use std::collections::HashMap;
 use wasm_encoder::{
     CodeSection, ConstExpr, DataSection, ExportSection, FunctionSection, MemorySection, MemoryType,
@@ -23,12 +23,9 @@ fn ir_type_to_wasm_type(ir_type: &IRType) -> ValType {
 pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     let mut module = Module::new();
     let mut ctx = CompilationContext::new();
-    let memory_layout = MemoryLayout::new();
-
-    // Pre-scan for string constants to allocate in memory
-    for _func in &ir_module.functions {
-        // TODO: Scan for string literals
-    }
+    // String/bytes offsets are resolved during lowering and carried on the IR
+    // module; the compiler reuses that layout to emit loads and the data section.
+    let memory_layout = ir_module.memory_layout.clone();
 
     // Build type section
     let mut types = TypeSection::new();
@@ -178,8 +175,6 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         data.active(0, &ConstExpr::i32_const(0), all_strings);
     }
 
-    module.section(&data);
-
     // Code section
     let mut codes = CodeSection::new();
 
@@ -196,7 +191,11 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         }
     }
 
+    // The WASM spec requires the Code section (id 10) before the Data section
+    // (id 11); emitting Data first produces a module that strict validators
+    // (and Binaryen's reader) reject, which previously disabled optimization.
     module.section(&codes);
+    module.section(&data);
 
     module.finish()
 }

--- a/src/ir/converter.rs
+++ b/src/ir/converter.rs
@@ -111,6 +111,10 @@ pub fn lower_ast_to_ir(ast: &Suite) -> Result<IRModule> {
     // Process circular imports
     process_circular_imports(&mut module);
 
+    // Carry the populated string/bytes layout to the compiler, which needs the
+    // resolved offsets to emit loads and the data section.
+    module.memory_layout = memory_layout;
+
     Ok(module)
 }
 
@@ -542,6 +546,14 @@ fn type_annotation_to_ir_type(expr: &Expr) -> Result<IRType> {
             "bytes" => Ok(IRType::Bytes),
             "None" => Ok(IRType::None),
             "Any" => Ok(IRType::Any),
+            // Bare builtin collection annotations (element types unknown).
+            "list" => Ok(IRType::List(Box::new(IRType::Unknown))),
+            "set" => Ok(IRType::Set(Box::new(IRType::Unknown))),
+            "tuple" => Ok(IRType::Tuple(vec![])),
+            "dict" => Ok(IRType::Dict(
+                Box::new(IRType::Unknown),
+                Box::new(IRType::Unknown),
+            )),
             _ => Ok(IRType::Class(name.id.to_string())),
         },
         Expr::Subscript(subscript) => {

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -6,6 +6,7 @@ pub struct IRModule {
     pub imports: Vec<IRImport>,     // Module-level imports
     pub classes: Vec<IRClass>,      // Module-level classes
     pub metadata: std::collections::HashMap<String, String>, // Module metadata
+    pub memory_layout: MemoryLayout, // String/bytes offsets and object heap layout
 }
 
 /// IR representation of a function
@@ -399,6 +400,27 @@ impl MemoryLayout {
         offset
     }
 
+    /// Merge the string and bytes entries from another layout, assigning fresh
+    /// non-colliding offsets here. Used when combining several lowered modules
+    /// into one binary. The IR references string/bytes *values* (offsets are
+    /// resolved at compile time), so re-adding by value is sufficient; entries
+    /// are processed in offset order for deterministic output.
+    pub fn merge_from(&mut self, other: &MemoryLayout) {
+        let mut strings: Vec<(&String, u32)> =
+            other.string_offsets.iter().map(|(s, &o)| (s, o)).collect();
+        strings.sort_by_key(|&(_, offset)| offset);
+        for (s, _) in strings {
+            self.add_string(s);
+        }
+
+        let mut bytes: Vec<(&Vec<u8>, u32)> =
+            other.bytes_offsets.iter().map(|(b, &o)| (b, o)).collect();
+        bytes.sort_by_key(|&(_, offset)| offset);
+        for (b, _) in bytes {
+            self.add_bytes(b);
+        }
+    }
+
     /// Allocate space for an object instance, returns pointer to allocated memory
     pub fn allocate_object(&mut self, size: u32) -> u32 {
         let ptr = self.object_heap_offset;
@@ -431,6 +453,7 @@ impl IRModule {
             imports: Vec::new(),
             classes: Vec::new(),
             metadata: std::collections::HashMap::new(),
+            memory_layout: MemoryLayout::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,11 @@ pub fn compile_multiple_python_files_with_options(
         combined_module.variables.extend(ir_module.variables);
         combined_module.imports.extend(ir_module.imports);
         combined_module.classes.extend(ir_module.classes);
+
+        // Merge this file's string/bytes layout into the combined module.
+        combined_module
+            .memory_layout
+            .merge_from(&ir_module.memory_layout);
     }
 
     if combined_module.functions.is_empty() {
@@ -399,6 +404,11 @@ pub fn compile_multiple_python_files_with_config(
         combined_module.variables.extend(ir_module.variables);
         combined_module.imports.extend(ir_module.imports);
         combined_module.classes.extend(ir_module.classes);
+
+        // Merge this file's string/bytes layout into the combined module.
+        combined_module
+            .memory_layout
+            .merge_from(&ir_module.memory_layout);
 
         // Add module-level metadata
         for (key, value) in ir_module.metadata {


### PR DESCRIPTION
waspy's compiled modules never executed: the Code section was emitted after Data, so runtimes (and Binaryen's reader) rejected the output. That masked a cascade of codegen bugs and silently disabled optimization. This makes the output runnable and fixes the collection paths so integer and string collections round-trip correctly.

Foundational (previously blocked all execution):
- Emit Code (id 10) before Data (id 11); optimization now runs.
- Reserve scratch locals per function so temporaries stop aliasing real variables / referencing undeclared local indices.
- Invert the `while` exit test; loops broke out immediately before.
- Map bare `list`/`dict`/`set`/`tuple` annotations to collection types.
- Carry the lowering-built `MemoryLayout` on `IRModule` and reuse it; the compiler used to rebuild an empty one, so every string resolved to offset 0 with no data section.

Collections:
- `dict[key] = value` updates an existing entry or appends a new one.
- Sets de-duplicate at construction; `in` / `not in` work for sets and lists. Fixes reversed store operands, broken index-read stack handling, the dict read that always returned 0, and `len()` for sets/tuples/bytes.