### PR TITLE
fix(codegen): runtime correctness for collections, floats, control flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - References to module-level variables (e.g. `PI = 3.14159`) were emitted as a `-999` sentinel; they are now resolved by inlining the variable's initializer, emitted at its natural type so `2 * PI` keeps `PI` an `f64`
 - **`int()` and `float()` actually convert**
   - Both previously passed their argument through unchanged; `int()` now truncates a float to `i32` and `float()` widens an int to `f64`
+- **`min()` / `max()` over multiple arguments**
+  - The reduction consumed the running value in the comparison and left the `if`/`else` arms unbalanced under an empty block type; rewritten as a result-typed fold that returns the correct minimum/maximum
+- **`os.path` submodule attributes** (e.g. `os.path.sep`)
+  - Accessing an attribute of a stdlib submodule fell through to a stray `drop` that underflowed the stack; submodule attributes are now resolved like module attributes
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Each list/set/tuple/dict/range literal now reserves its own region via a compile-time bump allocator; previously every same-type literal in a function shared a single address (e.g. `a = [1, 2]; b = [3, 4]` made `b` overwrite `a`), and nested literals collided
   - Memory is sized to the collection high-water mark; collection storage moved above the string/bytes/object regions
   - Known gap: a literal inside a loop still reuses its region across iterations
+- **`for ... in range(...)` loops now run** (ascending ranges)
+  - The loop's iterator helper locals were allocated after the function's local set was fixed, producing an out-of-range reference; they are now reserved up front (keyed per loop, so nested loops get distinct locals)
+  - The range object's `start`/`stop`/`step` fields were written with reversed store operands, so the loop read a `stop` of 0 and ran zero times; fixed
+  - Known gap: descending ranges (negative step, e.g. `range(10, 0, -1)`) still iterate zero times — the loop condition is ascending-only
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `dict[key] = value` now updates an existing entry or appends a new one
   - Sets de-duplicate at construction, and `in` / `not in` work for both sets and lists
   - Fixed reversed store operands, index-read stack handling, a dict read that always returned 0, and `len()` for sets, tuples, and bytes
+- **Float and integer elements in lists and tuples now read back correctly**
+  - Float elements are stored as f32 in the one-word-per-element layout (previously an 8-byte store into a 4-byte slot corrupted neighbouring elements)
+  - Unannotated collection locals keep their element type, so `xs[i]` no longer returns a constant `0`
+  - Expression statements no longer emit a stray `drop` after `print()` (which returns no value), which had produced invalid modules
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The loop's iterator helper locals were allocated after the function's local set was fixed, producing an out-of-range reference; they are now reserved up front (keyed per loop, so nested loops get distinct locals)
   - The range object's `start`/`stop`/`step` fields were written with reversed store operands, so the loop read a `stop` of 0 and ran zero times; fixed
   - Known gap: descending ranges (negative step, e.g. `range(10, 0, -1)`) still iterate zero times — the loop condition is ascending-only
+- **`try`/`except`/`finally` now compiles to a valid module**
+  - The exception-state locals (`__exception_flag`, `__exception_type`) were allocated during codegen after the local set was fixed; they are now reserved during the scan
+  - The exception-dispatch emitted one `End` too many, closing the function frame early ("function body shorter than given size"); now balanced. Bare, typed, finally-only, and nested `try` blocks all validate and run
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`try`/`except`/`finally` now compiles to a valid module**
   - The exception-state locals (`__exception_flag`, `__exception_type`) were allocated during codegen after the local set was fixed; they are now reserved during the scan
   - The exception-dispatch emitted one `End` too many, closing the function frame early ("function body shorter than given size"); now balanced. Bare, typed, finally-only, and nested `try` blocks all validate and run
+- **Float and mixed int/float numeric code is correct**
+  - `and` / `or` produced an empty-block-typed `if` while pushing a value; they now yield an `i32` result
+  - Mixed `int`/`float` arithmetic widens the integer operand to `f64` (the `int op float` case previously stashed an `f64` into an `i32` scratch local)
+  - Unannotated float locals (e.g. `result = 1.0`) are inferred as `f64` instead of defaulting to `i32`
+  - Function locals are declared in index order; they were grouped by type, which mis-mapped indices once a function mixed `int` and `float` locals
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Float elements are stored as f32 in the one-word-per-element layout (previously an 8-byte store into a 4-byte slot corrupted neighbouring elements)
   - Unannotated collection locals keep their element type, so `xs[i]` no longer returns a constant `0`
   - Expression statements no longer emit a stray `drop` after `print()` (which returns no value), which had produced invalid modules
+- **Collections no longer alias each other in memory** (Issue #14)
+  - Each list/set/tuple/dict/range literal now reserves its own region via a compile-time bump allocator; previously every same-type literal in a function shared a single address (e.g. `a = [1, 2]; b = [3, 4]` made `b` overwrite `a`), and nested literals collided
+  - Memory is sized to the collection high-water mark; collection storage moved above the string/bytes/object regions
+  - Known gap: a literal inside a loop still reuses its region across iterations
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,44 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Compiled modules now produce valid, runnable WebAssembly** ([#78](https://github.com/anistark/waspy/pull/78))
-  - Emit the Code section (id 10) before the Data section (id 11); previously the section order caused WASM runtimes and Binaryen to reject every module, which also silently disabled optimization
-  - Reserve scratch/temporary locals per function so intermediate calculations no longer alias real variables or reference undeclared local indices
-  - Inverted the `while` loop exit test that caused loops to break out immediately
-  - Map bare `list` / `dict` / `set` / `tuple` annotations to their collection types
-  - Carry the `MemoryLayout` built during AST lowering through to codegen instead of rebuilding an empty one, so strings resolve to the correct data offsets
-- **Collection runtime corrections** ([#78](https://github.com/anistark/waspy/pull/78))
-  - `dict[key] = value` now updates an existing entry or appends a new one
-  - Sets de-duplicate at construction, and `in` / `not in` work for both sets and lists
-  - Fixed reversed store operands, index-read stack handling, a dict read that always returned 0, and `len()` for sets, tuples, and bytes
-- **Float and integer elements in lists and tuples now read back correctly**
-  - Float elements are stored as f32 in the one-word-per-element layout (previously an 8-byte store into a 4-byte slot corrupted neighbouring elements)
-  - Unannotated collection locals keep their element type, so `xs[i]` no longer returns a constant `0`
-  - Expression statements no longer emit a stray `drop` after `print()` (which returns no value), which had produced invalid modules
-- **Collections no longer alias each other in memory** (Issue #14)
-  - Each list/set/tuple/dict/range literal now reserves its own region via a compile-time bump allocator; previously every same-type literal in a function shared a single address (e.g. `a = [1, 2]; b = [3, 4]` made `b` overwrite `a`), and nested literals collided
-  - Memory is sized to the collection high-water mark; collection storage moved above the string/bytes/object regions
-  - Known gap: a literal inside a loop still reuses its region across iterations
-- **`for ... in range(...)` loops now run** (ascending ranges)
-  - The loop's iterator helper locals were allocated after the function's local set was fixed, producing an out-of-range reference; they are now reserved up front (keyed per loop, so nested loops get distinct locals)
-  - The range object's `start`/`stop`/`step` fields were written with reversed store operands, so the loop read a `stop` of 0 and ran zero times; fixed
-  - Known gap: descending ranges (negative step, e.g. `range(10, 0, -1)`) still iterate zero times — the loop condition is ascending-only
-- **`try`/`except`/`finally` now compiles to a valid module**
-  - The exception-state locals (`__exception_flag`, `__exception_type`) were allocated during codegen after the local set was fixed; they are now reserved during the scan
-  - The exception-dispatch emitted one `End` too many, closing the function frame early ("function body shorter than given size"); now balanced. Bare, typed, finally-only, and nested `try` blocks all validate and run
-- **Float and mixed int/float numeric code is correct**
-  - `and` / `or` produced an empty-block-typed `if` while pushing a value; they now yield an `i32` result
-  - Mixed `int`/`float` arithmetic widens the integer operand to `f64` (the `int op float` case previously stashed an `f64` into an `i32` scratch local)
-  - Unannotated float locals (e.g. `result = 1.0`) are inferred as `f64` instead of defaulting to `i32`
-  - Function locals are declared in index order; they were grouped by type, which mis-mapped indices once a function mixed `int` and `float` locals
-- **Module-level variables resolve inside functions**
-  - References to module-level variables (e.g. `PI = 3.14159`) were emitted as a `-999` sentinel; they are now resolved by inlining the variable's initializer, emitted at its natural type so `2 * PI` keeps `PI` an `f64`
-- **`int()` and `float()` actually convert**
-  - Both previously passed their argument through unchanged; `int()` now truncates a float to `i32` and `float()` widens an int to `f64`
-- **`min()` / `max()` over multiple arguments**
-  - The reduction consumed the running value in the comparison and left the `if`/`else` arms unbalanced under an empty block type; rewritten as a result-typed fold that returns the correct minimum/maximum
-- **`os.path` submodule attributes** (e.g. `os.path.sep`)
-  - Accessing an attribute of a stdlib submodule fell through to a stray `drop` that underflowed the stack; submodule attributes are now resolved like module attributes
+- Compiled modules are valid and runnable: Code section before Data, per-function scratch locals, corrected `while` exit test, bare `list`/`dict`/`set`/`tuple` annotations, and `MemoryLayout` propagated to codegen ([#78](https://github.com/anistark/waspy/pull/78))
+- Collection runtime: `dict[key] = value` update/append, set de-duplication, `in`/`not in` for sets and lists, and `len()` for sets/tuples/bytes ([#78](https://github.com/anistark/waspy/pull/78))
+- Collections no longer alias in memory — each list/set/tuple/dict/range literal gets its own region via a compile-time bump allocator; distinct and nested literals previously shared one address (Issue #14)
+- Float elements in lists/tuples round-trip correctly (stored as f32 in the one-word slot), and unannotated collection locals keep their element type so `xs[i]` no longer returns `0`
+- `for ... in range(...)` iterates (ascending): iterator locals are reserved up front (nested loops get distinct locals) and range fields use the correct store operand order
+- `try`/`except`/`finally` compiles to a valid module: exception-state locals reserved in the scan, and balanced control flow (was emitting one `End` too many)
+- Numeric typing: `and`/`or` yield an `i32` result, mixed int/float arithmetic widens the int operand to `f64`, unannotated float locals infer as `f64`, and locals are declared in index order
+- Module-level variables (e.g. `PI = 3.14159`) resolve inside functions by inlining their initializer
+- `int()` / `float()` actually convert (truncate / widen); `min()` / `max()` reduce correctly; `os.path` submodule attributes (e.g. `os.path.sep`) resolve
+- Expression statements no longer emit a stray `drop` after `print()`
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Mixed `int`/`float` arithmetic widens the integer operand to `f64` (the `int op float` case previously stashed an `f64` into an `i32` scratch local)
   - Unannotated float locals (e.g. `result = 1.0`) are inferred as `f64` instead of defaulting to `i32`
   - Function locals are declared in index order; they were grouped by type, which mis-mapped indices once a function mixed `int` and `float` locals
+- **Module-level variables resolve inside functions**
+  - References to module-level variables (e.g. `PI = 3.14159`) were emitted as a `-999` sentinel; they are now resolved by inlining the variable's initializer, emitted at its natural type so `2 * PI` keeps `PI` an `f64`
+- **`int()` and `float()` actually convert**
+  - Both previously passed their argument through unchanged; `int()` now truncates a float to `i32` and `float()` widens an int to `f64`
 
 ## [0.9.0](https://github.com/anistark/waspy/releases/tag/v0.9.0) - 2025-12-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heck"
@@ -241,6 +251,7 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -882,8 +893,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
  "bitflags",
+ "hashbrown 0.15.2",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -900,6 +913,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,12 +164,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getopts"
@@ -199,10 +199,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-dependencies = [
- "foldhash",
- "serde",
-]
 
 [[package]]
 name = "heck"
@@ -251,8 +247,13 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
- "serde",
 ]
+
+[[package]]
+name = "indexmap-nostd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "is-macro"
@@ -676,6 +677,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,16 +900,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmi"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
+dependencies = [
+ "smallvec",
+ "spin",
+ "wasmi_arena",
+ "wasmi_core",
+ "wasmparser-nostd",
+]
+
+[[package]]
+name = "wasmi_arena"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+
+[[package]]
+name = "wasmi_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
+dependencies = [
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.2",
  "indexmap",
  "semver",
- "serde",
+]
+
+[[package]]
+name = "wasmparser-nostd"
+version = "0.100.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
+dependencies = [
+ "indexmap-nostd",
 ]
 
 [[package]]
@@ -913,7 +964,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "wasm-encoder",
- "wasmparser",
+ "wasmi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4"
 regex = "1.11"
 
 [dev-dependencies]
-wasmparser = "0.243.0"
+wasmi = "0.31"
 
 [lib]
 name = "waspy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ serde_json = "1.0"
 chrono = "0.4"
 regex = "1.11"
 
+[dev-dependencies]
+wasmparser = "0.243.0"
+
 [lib]
 name = "waspy"
 crate-type = ["cdylib", "rlib"]

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -243,12 +243,12 @@
                 status: "progress",
                 version: "in-dev",
                 features: [
+                    { name: "Set storage with de-duplication & membership (in / not in)", status: "done" },
+                    { name: "Dict index assignment with update or append (dict[key] = value)", status: "done" },
                     { name: "Generator State Management - execution context suspension/resumption", status: "progress" },
                     { name: "Dynamic Module Loading - runtime module loading and execution", status: "progress" },
                     { name: "Closure Variable Capture Analysis - detecting and capturing closure variables", status: "progress" },
-                    { name: "String Transformation in WASM - full character-by-char transformations", status: "progress" },
-                    { name: "Set Hashing & Storage - proper hash table implementation for sets", status: "progress" },
-                    { name: "Dictionary Index Assignment with Update - modifying dictionary values", status: "progress" }
+                    { name: "String Transformation in WASM - full character-by-char transformations", status: "progress" }
                 ]
             },
 

--- a/examples/list_float.py
+++ b/examples/list_float.py
@@ -1,0 +1,22 @@
+# Float collections round-trip through the one-word-per-element layout
+# (floats are stored as f32). See `just compile examples/list_float.py`.
+
+
+def midpoint() -> float:
+    pts = [1.5, 2.5, 3.5]
+    return pts[1]
+
+
+def total() -> float:
+    xs = [10.5, 20.25, 30.125]
+    return xs[0] + xs[1] + xs[2]
+
+
+def pair_second() -> float:
+    p = (1.25, 2.75)
+    return p[1]
+
+
+def int_list_index() -> int:
+    xs = [10, 20, 30]
+    return xs[1]

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -43,7 +43,8 @@ pub struct CompilationContext {
     pub local_count: u32,
     pub function_map: HashMap<String, FunctionInfo>,
     pub class_map: HashMap<String, ClassInfo>,
-    pub temp_local: u32, // For temporary calculations
+    pub temp_local: u32,     // For temporary calculations (i32 scratch)
+    pub temp_local_f64: u32, // Single f64 scratch local (operand juggling for coercions)
     /// Sequence counter for `for` loops, advanced in identical pre-order by the
     /// local-allocation scan and by codegen so each loop reuses the iterator
     /// helper locals (`__iter_*_{n}`) reserved for it. Reset per function.
@@ -66,6 +67,7 @@ impl CompilationContext {
             function_map: HashMap::new(),
             class_map: HashMap::new(),
             temp_local: 0,
+            temp_local_f64: 0,
             for_loop_seq: 0,
             collection_alloc_offset: Cell::new(0),
         }

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -1,4 +1,4 @@
-use crate::ir::IRType;
+use crate::ir::{IRExpr, IRType};
 use std::cell::Cell;
 use std::collections::HashMap;
 
@@ -43,6 +43,9 @@ pub struct CompilationContext {
     pub local_count: u32,
     pub function_map: HashMap<String, FunctionInfo>,
     pub class_map: HashMap<String, ClassInfo>,
+    /// Module-level variables, by name -> (declared type, initializer). Read
+    /// references to these are inlined by emitting the initializer expression.
+    pub module_vars: HashMap<String, (Option<IRType>, IRExpr)>,
     pub temp_local: u32,     // For temporary calculations (i32 scratch)
     pub temp_local_f64: u32, // Single f64 scratch local (operand juggling for coercions)
     /// Sequence counter for `for` loops, advanced in identical pre-order by the
@@ -66,6 +69,7 @@ impl CompilationContext {
             local_count: 0,
             function_map: HashMap::new(),
             class_map: HashMap::new(),
+            module_vars: HashMap::new(),
             temp_local: 0,
             temp_local_f64: 0,
             for_loop_seq: 0,
@@ -139,5 +143,15 @@ impl CompilationContext {
     /// Get information about a class by name
     pub fn get_class_info(&self, name: &str) -> Option<&ClassInfo> {
         self.class_map.get(name)
+    }
+
+    /// Register a module-level variable and its initializer.
+    pub fn add_module_var(&mut self, name: &str, var_type: Option<IRType>, value: IRExpr) {
+        self.module_vars.insert(name.to_string(), (var_type, value));
+    }
+
+    /// Look up a module-level variable's (declared type, initializer).
+    pub fn get_module_var(&self, name: &str) -> Option<&(Option<IRType>, IRExpr)> {
+        self.module_vars.get(name)
     }
 }

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -44,6 +44,10 @@ pub struct CompilationContext {
     pub function_map: HashMap<String, FunctionInfo>,
     pub class_map: HashMap<String, ClassInfo>,
     pub temp_local: u32, // For temporary calculations
+    /// Sequence counter for `for` loops, advanced in identical pre-order by the
+    /// local-allocation scan and by codegen so each loop reuses the iterator
+    /// helper locals (`__iter_*_{n}`) reserved for it. Reset per function.
+    pub for_loop_seq: u32,
     /// Running high-water mark of the collection heap, in bytes past
     /// `COLLECTION_HEAP_BASE`. Each literal reserves a fresh region here, so it
     /// grows monotonically across the whole module. A `Cell` because codegen
@@ -62,6 +66,7 @@ impl CompilationContext {
             function_map: HashMap::new(),
             class_map: HashMap::new(),
             temp_local: 0,
+            for_loop_seq: 0,
             collection_alloc_offset: Cell::new(0),
         }
     }

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -1,4 +1,5 @@
 use crate::ir::IRType;
+use std::cell::Cell;
 use std::collections::HashMap;
 
 /// Number of scratch/temporary locals reserved for intermediate calculations
@@ -7,6 +8,11 @@ use std::collections::HashMap;
 /// indices never alias real variables. Keep this >= the largest `temp_local + N`
 /// offset emitted anywhere in the compiler.
 pub const SCRATCH_LOCALS: u32 = 8;
+
+/// Base address of the collection heap. Sits above the string (from 0), bytes
+/// (from 32768), and object-instance (from 65536) regions so collection
+/// literals never overlap them.
+pub const COLLECTION_HEAP_BASE: u32 = 131072;
 
 /// Local variable
 pub struct LocalInfo {
@@ -38,6 +44,11 @@ pub struct CompilationContext {
     pub function_map: HashMap<String, FunctionInfo>,
     pub class_map: HashMap<String, ClassInfo>,
     pub temp_local: u32, // For temporary calculations
+    /// Running high-water mark of the collection heap, in bytes past
+    /// `COLLECTION_HEAP_BASE`. Each literal reserves a fresh region here, so it
+    /// grows monotonically across the whole module. A `Cell` because codegen
+    /// holds `&CompilationContext` while allocating.
+    pub collection_alloc_offset: Cell<u32>,
 }
 
 impl CompilationContext {
@@ -51,7 +62,19 @@ impl CompilationContext {
             function_map: HashMap::new(),
             class_map: HashMap::new(),
             temp_local: 0,
+            collection_alloc_offset: Cell::new(0),
         }
+    }
+
+    /// Reserve a fresh, uniquely addressed region of `size` bytes for a
+    /// collection literal and return its compile-time base pointer. Distinct
+    /// (and nested) literals get distinct regions, so they never alias. Sizes
+    /// are rounded up to 8 bytes to keep f64/dict-entry slots aligned.
+    pub fn alloc_collection(&self, size: u32) -> u32 {
+        let aligned = (size + 7) & !7;
+        let offset = self.collection_alloc_offset.get();
+        self.collection_alloc_offset.set(offset + aligned);
+        COLLECTION_HEAP_BASE + offset
     }
 
     /// Add a local variable to the context

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -140,14 +140,19 @@ pub fn emit_expr(
             if let Some(local_info) = ctx.get_local_info(name) {
                 func.instruction(&Instruction::LocalGet(local_info.index));
                 local_info.var_type.clone()
+            } else if let Some((declared, value)) = ctx.get_module_var(name) {
+                // Module-level variable: inline its initializer. Clone first so
+                // the recursive emit does not alias the borrow of `ctx`. Emit at
+                // the value's natural type (expected_type None) — passing the
+                // caller's expectation through would, e.g., truncate a float
+                // constant to i32 in `2 * PI`.
+                let declared = declared.clone();
+                let value = value.clone();
+                let emitted = emit_expr(&value, func, ctx, memory_layout, None);
+                declared.unwrap_or(emitted)
             } else {
-                // Default to i32 if type info is missing
-                if let Some(local_idx) = ctx.get_local_index(name) {
-                    func.instruction(&Instruction::LocalGet(local_idx));
-                } else {
-                    // Indicate an error or unknown variable
-                    func.instruction(&Instruction::I32Const(-999));
-                }
+                // Unknown variable
+                func.instruction(&Instruction::I32Const(-999));
                 IRType::Unknown
             }
         }
@@ -879,6 +884,20 @@ pub fn emit_expr(
                             func.instruction(&Instruction::End);
                         }
                         result_type
+                    }
+                    "int" => {
+                        // int(x): truncate a float to i32; ints pass through.
+                        if matches!(arg_types.first(), Some(IRType::Float)) {
+                            func.instruction(&Instruction::I32TruncF64S);
+                        }
+                        IRType::Int
+                    }
+                    "float" => {
+                        // float(x): widen an int to f64; floats pass through.
+                        if !matches!(arg_types.first(), Some(IRType::Float)) {
+                            func.instruction(&Instruction::F64ConvertI32S);
+                        }
+                        IRType::Float
                     }
                     "sum" => {
                         if arg_types.is_empty() {

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -827,26 +827,21 @@ pub fn emit_expr(
                             func.instruction(&Instruction::Drop);
                             return IRType::Int;
                         }
-                        // min(a, b, ...) - multiple arguments
+                        // min(a, b, ...) - fold the args (top of stack down) into
+                        // a running minimum. Each step replaces the top two with
+                        // their minimum via a result-typed if.
                         let result_type = arg_types[0].clone();
-                        // Stack after emit_expr: arg0, arg1, arg2, ...
-                        // Compare pairs and keep minimum
                         for _ in 1..arg_types.len() {
-                            // Stack: ..., min_so_far, next_val
-                            // Save next_val, then compare
-                            func.instruction(&Instruction::LocalSet(ctx.temp_local));
-                            // Stack: ..., min_so_far
+                            // Stack: ..., running, next
+                            func.instruction(&Instruction::LocalSet(ctx.temp_local + 1)); // next
+                            func.instruction(&Instruction::LocalSet(ctx.temp_local)); // running
                             func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                            // Stack: ..., min_so_far, next_val
-                            func.instruction(&Instruction::I32LtS);
-                            func.instruction(&Instruction::If(BlockType::Empty));
-                            // next_val < min_so_far, so pop min_so_far and keep next_val
-                            func.instruction(&Instruction::Drop);
-                            func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
+                            func.instruction(&Instruction::I32LtS); // running < next
+                            func.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local)); // keep running
                             func.instruction(&Instruction::Else);
-                            // min_so_far <= next_val, drop next_val and keep min_so_far
-                            func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                            func.instruction(&Instruction::Drop);
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 1)); // keep next
                             func.instruction(&Instruction::End);
                         }
                         result_type
@@ -861,26 +856,19 @@ pub fn emit_expr(
                             func.instruction(&Instruction::Drop);
                             return IRType::Int;
                         }
-                        // max(a, b, ...) - multiple arguments
+                        // max(a, b, ...) - fold the args into a running maximum.
                         let result_type = arg_types[0].clone();
-                        // Stack after emit_expr: arg0, arg1, arg2, ...
-                        // Compare pairs and keep maximum
                         for _ in 1..arg_types.len() {
-                            // Stack: ..., max_so_far, next_val
-                            // Save next_val, then compare
-                            func.instruction(&Instruction::LocalSet(ctx.temp_local));
-                            // Stack: ..., max_so_far
+                            // Stack: ..., running, next
+                            func.instruction(&Instruction::LocalSet(ctx.temp_local + 1)); // next
+                            func.instruction(&Instruction::LocalSet(ctx.temp_local)); // running
                             func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                            // Stack: ..., max_so_far, next_val
-                            func.instruction(&Instruction::I32GtS);
-                            func.instruction(&Instruction::If(BlockType::Empty));
-                            // max_so_far > next_val, keep max_so_far
-                            func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                            func.instruction(&Instruction::Drop);
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
+                            func.instruction(&Instruction::I32GtS); // running > next
+                            func.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local)); // keep running
                             func.instruction(&Instruction::Else);
-                            // max_so_far <= next_val, so pop max_so_far and keep next_val
-                            func.instruction(&Instruction::Drop);
-                            func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 1)); // keep next
                             func.instruction(&Instruction::End);
                         }
                         result_type
@@ -1602,47 +1590,57 @@ pub fn emit_expr(
             }
         }
         IRExpr::Attribute { object, attribute } => {
-            if let IRExpr::Variable(module_name) = &**object {
-                if crate::stdlib::is_stdlib_module(module_name) {
-                    if let Some(value) =
-                        crate::stdlib::get_stdlib_attributes(module_name, attribute)
-                    {
-                        return match value {
-                            crate::stdlib::StdlibValue::Int(i) => {
-                                func.instruction(&Instruction::I32Const(i));
-                                IRType::Int
-                            }
-                            crate::stdlib::StdlibValue::String(s) => {
-                                let offset =
-                                    memory_layout.string_offsets.get(&s).copied().unwrap_or(0);
-                                func.instruction(&Instruction::I32Const(offset as i32));
-                                func.instruction(&Instruction::I32Const(s.len() as i32));
-                                IRType::String
-                            }
-                            crate::stdlib::StdlibValue::Float(f) => {
-                                func.instruction(&Instruction::F64Const(f.into()));
-                                IRType::Float
-                            }
-                            crate::stdlib::StdlibValue::List(_) => {
-                                func.instruction(&Instruction::I32Const(10000));
-                                IRType::List(Box::new(IRType::String))
-                            }
-                            crate::stdlib::StdlibValue::Dict(_) => {
-                                func.instruction(&Instruction::I32Const(10000));
-                                IRType::Dict(Box::new(IRType::String), Box::new(IRType::String))
-                            }
-                            crate::stdlib::StdlibValue::None => {
-                                func.instruction(&Instruction::I32Const(0));
-                                IRType::None
-                            }
-                            crate::stdlib::StdlibValue::Module(module_name) => {
-                                // Module doesn't need to push anything to the stack
-                                // Just return the Module type for further processing
-                                IRType::Module(module_name)
-                            }
-                        };
-                    }
+            // Resolve a stdlib attribute, whether on a module (`os.sep`) or a
+            // submodule (`os.path.sep`, where `object` is itself `os.path`).
+            let stdlib_value = match &**object {
+                IRExpr::Variable(module_name) if crate::stdlib::is_stdlib_module(module_name) => {
+                    crate::stdlib::get_stdlib_attributes(module_name, attribute)
                 }
+                IRExpr::Attribute {
+                    object: inner,
+                    attribute: sub,
+                } => match &**inner {
+                    IRExpr::Variable(parent) if crate::stdlib::is_stdlib_submodule(parent, sub) => {
+                        crate::stdlib::get_submodule_attribute(parent, sub, attribute)
+                    }
+                    _ => None,
+                },
+                _ => None,
+            };
+
+            if let Some(value) = stdlib_value {
+                return match value {
+                    crate::stdlib::StdlibValue::Int(i) => {
+                        func.instruction(&Instruction::I32Const(i));
+                        IRType::Int
+                    }
+                    crate::stdlib::StdlibValue::String(s) => {
+                        let offset = memory_layout.string_offsets.get(&s).copied().unwrap_or(0);
+                        func.instruction(&Instruction::I32Const(offset as i32));
+                        func.instruction(&Instruction::I32Const(s.len() as i32));
+                        IRType::String
+                    }
+                    crate::stdlib::StdlibValue::Float(f) => {
+                        func.instruction(&Instruction::F64Const(f.into()));
+                        IRType::Float
+                    }
+                    crate::stdlib::StdlibValue::List(_) => {
+                        func.instruction(&Instruction::I32Const(10000));
+                        IRType::List(Box::new(IRType::String))
+                    }
+                    crate::stdlib::StdlibValue::Dict(_) => {
+                        func.instruction(&Instruction::I32Const(10000));
+                        IRType::Dict(Box::new(IRType::String), Box::new(IRType::String))
+                    }
+                    crate::stdlib::StdlibValue::None => {
+                        func.instruction(&Instruction::I32Const(0));
+                        IRType::None
+                    }
+                    crate::stdlib::StdlibValue::Module(module_name) => {
+                        // Module doesn't need to push anything to the stack
+                        IRType::Module(module_name)
+                    }
+                };
             }
 
             let obj_type = emit_expr(object, func, ctx, memory_layout, None);

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -3383,63 +3383,49 @@ pub fn emit_expr(
             // Range object layout in memory: [start:i32][stop:i32][step:i32][current:i32]
             let range_ptr = ctx.alloc_collection(16);
 
-            // Evaluate and store start (default 0)
+            // Each field store pushes the destination address *before* the value
+            // (a WASM store pops the value first, then the address). range_ptr is
+            // a constant, so the field offset goes in the store's MemArg.
+            let store_field = |func: &mut Function, offset: u64| {
+                func.instruction(&Instruction::I32Store(MemArg {
+                    offset,
+                    align: 2,
+                    memory_index: 0,
+                }));
+            };
+
+            // start (default 0) at offset 0
+            func.instruction(&Instruction::I32Const(range_ptr as i32));
             if let Some(s) = start {
                 emit_expr(s, func, ctx, memory_layout, Some(&IRType::Int));
             } else {
                 func.instruction(&Instruction::I32Const(0));
             }
+            store_field(func, 0);
 
+            // stop at offset 4
             func.instruction(&Instruction::I32Const(range_ptr as i32));
-            func.instruction(&Instruction::LocalSet(ctx.temp_local));
-            func.instruction(&Instruction::LocalGet(ctx.temp_local));
-            func.instruction(&Instruction::I32Store(MemArg {
-                offset: 0,
-                align: 2,
-                memory_index: 0,
-            }));
-
-            // Evaluate and store stop
             emit_expr(stop, func, ctx, memory_layout, Some(&IRType::Int));
-            func.instruction(&Instruction::LocalGet(ctx.temp_local));
-            func.instruction(&Instruction::I32Const(4));
-            func.instruction(&Instruction::I32Add);
-            func.instruction(&Instruction::I32Store(MemArg {
-                offset: 0,
-                align: 2,
-                memory_index: 0,
-            }));
+            store_field(func, 4);
 
-            // Evaluate and store step (default 1)
+            // step (default 1) at offset 8
+            func.instruction(&Instruction::I32Const(range_ptr as i32));
             if let Some(s) = step {
                 emit_expr(s, func, ctx, memory_layout, Some(&IRType::Int));
             } else {
                 func.instruction(&Instruction::I32Const(1));
             }
-            func.instruction(&Instruction::LocalGet(ctx.temp_local));
-            func.instruction(&Instruction::I32Const(8));
-            func.instruction(&Instruction::I32Add);
-            func.instruction(&Instruction::I32Store(MemArg {
-                offset: 0,
-                align: 2,
-                memory_index: 0,
-            }));
+            store_field(func, 8);
 
-            // Store current position (same as start)
-            func.instruction(&Instruction::LocalGet(ctx.temp_local));
+            // current = start at offset 12
+            func.instruction(&Instruction::I32Const(range_ptr as i32));
+            func.instruction(&Instruction::I32Const(range_ptr as i32));
             func.instruction(&Instruction::I32Load(MemArg {
                 offset: 0,
                 align: 2,
                 memory_index: 0,
             }));
-            func.instruction(&Instruction::LocalGet(ctx.temp_local));
-            func.instruction(&Instruction::I32Const(12));
-            func.instruction(&Instruction::I32Add);
-            func.instruction(&Instruction::I32Store(MemArg {
-                offset: 0,
-                align: 2,
-                memory_index: 0,
-            }));
+            store_field(func, 12);
 
             // Return pointer to range object
             func.instruction(&Instruction::I32Const(range_ptr as i32));

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -923,17 +923,23 @@ pub fn emit_expr(
         }
         IRExpr::ListLiteral(elements) => {
             // List layout in memory: [length:i32][elem0:i32][elem1:i32]...
-            // For now, allocate after string data (at offset 10000)
-            // Each element takes 4 bytes for i32 values
+            // Each element takes 4 bytes.
 
             if elements.is_empty() {
-                // Empty list: just a length of 0
-                func.instruction(&Instruction::I32Const(10000)); // Pointer to empty list
+                // Empty list: a header with length 0.
+                let list_ptr = ctx.alloc_collection(4);
+                func.instruction(&Instruction::I32Const(list_ptr as i32));
+                func.instruction(&Instruction::I32Const(0));
+                func.instruction(&Instruction::I32Store(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::I32Const(list_ptr as i32));
                 return IRType::List(Box::new(IRType::Unknown));
             }
 
-            // Use a fixed allocation address for simplicity
-            let list_ptr = 10000 + (ctx.local_count * 100);
+            let list_ptr = ctx.alloc_collection(4 + elements.len() as u32 * 4);
 
             // Store length at the beginning
             func.instruction(&Instruction::I32Const(list_ptr as i32));
@@ -974,19 +980,19 @@ pub fn emit_expr(
 
             // Empty set: store a count of 0 so membership tests read a valid header.
             if elements.is_empty() {
-                func.instruction(&Instruction::I32Const(20000));
+                let set_ptr = ctx.alloc_collection(4);
+                func.instruction(&Instruction::I32Const(set_ptr as i32));
                 func.instruction(&Instruction::I32Const(0));
                 func.instruction(&Instruction::I32Store(MemArg {
                     offset: 0,
                     align: 2,
                     memory_index: 0,
                 }));
-                func.instruction(&Instruction::I32Const(20000));
+                func.instruction(&Instruction::I32Const(set_ptr as i32));
                 return IRType::Set(Box::new(IRType::Unknown));
             }
 
-            // Use a fixed allocation address for simplicity.
-            let set_ptr = 20000 + (ctx.local_count * 100);
+            let set_ptr = ctx.alloc_collection(4 + elements.len() as u32 * 4);
 
             // Start with an empty set (count = 0).
             func.instruction(&Instruction::I32Const(set_ptr as i32));
@@ -1089,14 +1095,21 @@ pub fn emit_expr(
         }
         IRExpr::TupleLiteral(elements) => {
             // Tuple layout in memory: [length:i32][elem0:i32][elem1:i32]...
-            // Fixed-size tuples allocated after sets (at offset 30000+)
 
             if elements.is_empty() {
-                func.instruction(&Instruction::I32Const(30000));
+                let tuple_ptr = ctx.alloc_collection(4);
+                func.instruction(&Instruction::I32Const(tuple_ptr as i32));
+                func.instruction(&Instruction::I32Const(0));
+                func.instruction(&Instruction::I32Store(MemArg {
+                    offset: 0,
+                    align: 2,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::I32Const(tuple_ptr as i32));
                 return IRType::Tuple(vec![]);
             }
 
-            let tuple_ptr = 30000 + (ctx.local_count * 100);
+            let tuple_ptr = ctx.alloc_collection(4 + elements.len() as u32 * 4);
 
             // Store length at the beginning
             func.instruction(&Instruction::I32Const(tuple_ptr as i32));
@@ -1127,8 +1140,7 @@ pub fn emit_expr(
         }
         IRExpr::DictLiteral(pairs) => {
             // Dict layout in memory: [num_entries:i32][key0:i32][val0:i32][key1:i32][val1:i32]...
-            // Allocate dict at a fixed offset (after lists)
-            let dict_ptr = 50000 + (ctx.local_count * 100);
+            let dict_ptr = ctx.alloc_collection(4 + pairs.len() as u32 * 8);
 
             // Store number of entries
             func.instruction(&Instruction::I32Const(dict_ptr as i32));
@@ -3369,8 +3381,7 @@ pub fn emit_expr(
         }
         IRExpr::RangeCall { start, stop, step } => {
             // Range object layout in memory: [start:i32][stop:i32][step:i32][current:i32]
-            // Allocate range object at offset 40000+
-            let range_ptr = 40000 + (ctx.local_count * 100);
+            let range_ptr = ctx.alloc_collection(16);
 
             // Evaluate and store start (default 0)
             if let Some(s) = start {

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -1,6 +1,6 @@
 use crate::compiler::context::CompilationContext;
 use crate::ir::{IRBoolOp, IRCompareOp, IRConstant, IRExpr, IROp, IRType, IRUnaryOp, MemoryLayout};
-use wasm_encoder::{BlockType, Function, Instruction, MemArg};
+use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
 
 // Helper to convert f64 to Ieee64
 #[inline]
@@ -344,14 +344,19 @@ pub fn emit_expr(
                 }
             }
 
-            if left_type == IRType::Float && right_type == IRType::Int {
-                // Convert right operand from i32 to f64
+            // int/bool/unknown values are all i32-represented; widen the i32
+            // side to f64 when the other operand is a float.
+            let left_int_like = matches!(left_type, IRType::Int | IRType::Bool | IRType::Unknown);
+            let right_int_like = matches!(right_type, IRType::Int | IRType::Bool | IRType::Unknown);
+            if left_type == IRType::Float && right_int_like {
+                // Right operand (top of stack) is i32; widen it to f64.
                 func.instruction(&Instruction::F64ConvertI32S);
-            } else if left_type == IRType::Int && right_type == IRType::Float {
-                // Move stack: f64 under i32
-                func.instruction(&Instruction::LocalSet(ctx.temp_local));
+            } else if left_int_like && right_type == IRType::Float {
+                // Left operand is the i32 buried under the f64 right operand.
+                // Stash the f64 (needs an f64 local), widen the int, restore.
+                func.instruction(&Instruction::LocalSet(ctx.temp_local_f64));
                 func.instruction(&Instruction::F64ConvertI32S);
-                func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                func.instruction(&Instruction::LocalGet(ctx.temp_local_f64));
             }
 
             let result_type = if left_type == IRType::Float || right_type == IRType::Float {
@@ -687,8 +692,9 @@ pub fn emit_expr(
                     func.instruction(&Instruction::LocalSet(ctx.temp_local));
                     func.instruction(&Instruction::LocalGet(ctx.temp_local));
 
-                    // If-else pattern for short-circuit evaluation
-                    func.instruction(&Instruction::If(BlockType::Empty));
+                    // If-else pattern for short-circuit evaluation. Both arms
+                    // leave the boolean result, so the if yields an i32.
+                    func.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
                     emit_expr(right, func, ctx, memory_layout, Some(&IRType::Bool));
                     func.instruction(&Instruction::Else);
                     func.instruction(&Instruction::I32Const(0)); // False
@@ -700,8 +706,9 @@ pub fn emit_expr(
                     func.instruction(&Instruction::LocalSet(ctx.temp_local));
                     func.instruction(&Instruction::LocalGet(ctx.temp_local));
 
-                    // If-else pattern for short-circuit evaluation
-                    func.instruction(&Instruction::If(BlockType::Empty));
+                    // If-else pattern for short-circuit evaluation. Both arms
+                    // leave the boolean result, so the if yields an i32.
+                    func.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
                     func.instruction(&Instruction::I32Const(1)); // True
                     func.instruction(&Instruction::Else);
                     emit_expr(right, func, ctx, memory_layout, Some(&IRType::Bool));

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -18,6 +18,46 @@ fn narrow_element_to_word(func: &mut Function, elem_type: &IRType) {
     }
 }
 
+/// Store the value on top of the stack into a 4-byte collection slot (the
+/// destination address must be pushed first). Floats are narrowed to f32 so
+/// they fit the one-word-per-element layout; everything else is already an
+/// i32 word (ints, bools, interned string/bytes offsets).
+fn store_collection_word(func: &mut Function, elem_type: &IRType) {
+    if matches!(elem_type, IRType::Float) {
+        func.instruction(&Instruction::F32DemoteF64);
+        func.instruction(&Instruction::F32Store(MemArg {
+            offset: 0,
+            align: 2,
+            memory_index: 0,
+        }));
+    } else {
+        func.instruction(&Instruction::I32Store(MemArg {
+            offset: 0,
+            align: 2,
+            memory_index: 0,
+        }));
+    }
+}
+
+/// Load a 4-byte collection slot (address on top of the stack), widening f32
+/// float slots back to the f64 the rest of the compiler works with.
+fn load_collection_word(func: &mut Function, elem_type: &IRType) {
+    if matches!(elem_type, IRType::Float) {
+        func.instruction(&Instruction::F32Load(MemArg {
+            offset: 0,
+            align: 2,
+            memory_index: 0,
+        }));
+        func.instruction(&Instruction::F64PromoteF32);
+    } else {
+        func.instruction(&Instruction::I32Load(MemArg {
+            offset: 0,
+            align: 2,
+            memory_index: 0,
+        }));
+    }
+}
+
 /// Emit WebAssembly instructions for an IR expression
 pub fn emit_expr(
     expr: &IRExpr,
@@ -915,23 +955,7 @@ pub fn emit_expr(
                 func.instruction(&Instruction::I32Const(addr as i32));
                 let ty = emit_expr(elem, func, ctx, memory_layout, None);
                 narrow_element_to_word(func, &ty);
-
-                match ty {
-                    IRType::Float => {
-                        func.instruction(&Instruction::F64Store(MemArg {
-                            offset: 0,
-                            align: 3,
-                            memory_index: 0,
-                        }));
-                    }
-                    _ => {
-                        func.instruction(&Instruction::I32Store(MemArg {
-                            offset: 0,
-                            align: 2,
-                            memory_index: 0,
-                        }));
-                    }
-                }
+                store_collection_word(func, &ty);
 
                 if i == 0 {
                     elem_type = ty;
@@ -1094,24 +1118,8 @@ pub fn emit_expr(
                 func.instruction(&Instruction::I32Const(addr as i32));
                 let elem_type = emit_expr(elem, func, ctx, memory_layout, None);
                 narrow_element_to_word(func, &elem_type);
-                element_types.push(elem_type.clone());
-
-                match elem_type {
-                    IRType::Float => {
-                        func.instruction(&Instruction::F64Store(MemArg {
-                            offset: 0,
-                            align: 3,
-                            memory_index: 0,
-                        }));
-                    }
-                    _ => {
-                        func.instruction(&Instruction::I32Store(MemArg {
-                            offset: 0,
-                            align: 2,
-                            memory_index: 0,
-                        }));
-                    }
-                }
+                store_collection_word(func, &elem_type);
+                element_types.push(elem_type);
             }
 
             func.instruction(&Instruction::I32Const(tuple_ptr as i32));
@@ -1222,23 +1230,7 @@ pub fn emit_expr(
                     func.instruction(&Instruction::I32Add); // index*4 + 4
                     func.instruction(&Instruction::I32Add); // list_ptr + index*4 + 4
 
-                    // Load the element based on element type
-                    match element_type.as_ref() {
-                        IRType::Float => {
-                            func.instruction(&Instruction::F64Load(MemArg {
-                                offset: 0,
-                                align: 3,
-                                memory_index: 0,
-                            }));
-                        }
-                        _ => {
-                            func.instruction(&Instruction::I32Load(MemArg {
-                                offset: 0,
-                                align: 2,
-                                memory_index: 0,
-                            }));
-                        }
-                    }
+                    load_collection_word(func, element_type.as_ref());
 
                     element_type.as_ref().clone()
                 }
@@ -1349,22 +1341,7 @@ pub fn emit_expr(
                         IRType::Unknown
                     };
 
-                    match &elem_type {
-                        IRType::Float => {
-                            func.instruction(&Instruction::F64Load(MemArg {
-                                offset: 0,
-                                align: 3,
-                                memory_index: 0,
-                            }));
-                        }
-                        _ => {
-                            func.instruction(&Instruction::I32Load(MemArg {
-                                offset: 0,
-                                align: 2,
-                                memory_index: 0,
-                            }));
-                        }
-                    }
+                    load_collection_word(func, &elem_type);
 
                     elem_type
                 }

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -198,7 +198,28 @@ pub fn compile_body(
                     .or_else(|| ctx.get_local_info(target).map(|info| info.var_type.clone()));
 
                 // Emit code for the value
-                emit_expr(value, func, ctx, memory_layout, expected_type.as_ref());
+                let value_type = emit_expr(value, func, ctx, memory_layout, expected_type.as_ref());
+
+                // An unannotated local is allocated as Unknown (an i32 slot).
+                // Recover the element/entry types of collections so later
+                // indexing knows how to load each slot. Only pointer-shaped
+                // types are adopted, since they share that same i32 slot and
+                // won't disturb the already-fixed local layout.
+                if let Some(info) = ctx.locals_map.get_mut(target) {
+                    if matches!(info.var_type, IRType::Unknown)
+                        && matches!(
+                            value_type,
+                            IRType::List(_)
+                                | IRType::Tuple(_)
+                                | IRType::Dict(_, _)
+                                | IRType::Set(_)
+                                | IRType::String
+                                | IRType::Bytes
+                        )
+                    {
+                        info.var_type = value_type;
+                    }
+                }
 
                 if let Some(local_idx) = ctx.get_local_index(target) {
                     func.instruction(&Instruction::LocalSet(local_idx));
@@ -321,8 +342,13 @@ pub fn compile_body(
                 func.instruction(&Instruction::End);
             }
             IRStatement::Expression(expr) => {
-                emit_expr(expr, func, ctx, memory_layout, None);
-                func.instruction(&Instruction::Drop);
+                // Discard the result only when the expression actually leaves a
+                // value. Calls like print() return None and push nothing, so an
+                // unconditional drop would underflow the stack.
+                let result_type = emit_expr(expr, func, ctx, memory_layout, None);
+                if !matches!(result_type, IRType::None) {
+                    func.instruction(&Instruction::Drop);
+                }
             }
             IRStatement::AttributeAssign {
                 object,

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -89,6 +89,16 @@ fn get_local_type_by_index(ctx: &CompilationContext, index: u32) -> IRType {
     IRType::Int // Default to i32
 }
 
+/// Reserve a named local if it has not been allocated yet. Used by the scan to
+/// pre-declare the compiler's internal helper locals (exception state, context
+/// managers, ...) so codegen never adds locals after the function's local
+/// vector is fixed.
+fn ensure_local(ctx: &mut CompilationContext, name: &str, var_type: IRType) {
+    if ctx.get_local_index(name).is_none() {
+        ctx.add_local(name, var_type);
+    }
+}
+
 /// Scan the function body for variable declarations and allocate local variables
 pub fn scan_and_allocate_locals(body: &IRBody, ctx: &mut CompilationContext) {
     for stmt in &body.statements {
@@ -144,11 +154,19 @@ pub fn scan_and_allocate_locals(body: &IRBody, ctx: &mut CompilationContext) {
                     scan_and_allocate_locals(else_body, ctx);
                 }
             }
+            IRStatement::Raise { .. } => {
+                // Raise uses the shared exception-state locals; reserve them so
+                // codegen never has to add locals after the local set is fixed.
+                ensure_local(ctx, "__exception_flag", IRType::Int);
+                ensure_local(ctx, "__exception_type", IRType::Int);
+            }
             IRStatement::TryExcept {
                 try_body,
                 except_handlers,
                 finally_body,
             } => {
+                ensure_local(ctx, "__exception_flag", IRType::Int);
+                ensure_local(ctx, "__exception_type", IRType::Int);
                 scan_and_allocate_locals(try_body, ctx);
 
                 for handler in except_handlers {
@@ -663,8 +681,13 @@ pub fn compile_body(
             } => {
                 // Implement exception handling with a global exception state
                 // We use a special local variable to track if an exception was raised
-                let exception_flag_idx = ctx.add_local("__exception_flag", IRType::Int);
-                let exception_type_idx = ctx.add_local("__exception_type", IRType::Int);
+                // Reuse the exception-state locals reserved during the scan.
+                let exception_flag_idx = ctx
+                    .get_local_index("__exception_flag")
+                    .unwrap_or_else(|| ctx.add_local("__exception_flag", IRType::Int));
+                let exception_type_idx = ctx
+                    .get_local_index("__exception_type")
+                    .unwrap_or_else(|| ctx.add_local("__exception_type", IRType::Int));
 
                 // Initialize exception flag to 0 (no exception)
                 func.instruction(&Instruction::I32Const(0));

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -16,7 +16,9 @@ pub fn compile_function(
         ctx.add_local(&param.name, param.param_type.clone());
     }
 
-    // Scan for variable declarations to allocate locals
+    // Scan for variable declarations to allocate locals. The for-loop counter
+    // is advanced during the scan and replayed during codegen, so reset it here.
+    ctx.for_loop_seq = 0;
     scan_and_allocate_locals(&ir_func.body, ctx);
 
     // Reserve scratch locals after all params and named locals so temporary
@@ -51,6 +53,10 @@ pub fn compile_function(
     }
 
     let mut func = Function::new(locals);
+
+    // Replay the same for-loop numbering used by the scan above so codegen
+    // resolves the matching iterator helper locals.
+    ctx.for_loop_seq = 0;
 
     // Compile the function body
     compile_body(&ir_func.body, &mut func, ctx, memory_layout);
@@ -125,6 +131,14 @@ pub fn scan_and_allocate_locals(body: &IRBody, ctx: &mut CompilationContext) {
                 if ctx.get_local_index(target).is_none() {
                     ctx.add_local(target, IRType::Unknown);
                 }
+                // Reserve this loop's iterator helper locals up front (codegen
+                // can't add locals after the function's local vector is fixed).
+                // Keyed by sequence number so nested loops get distinct locals.
+                let seq = ctx.for_loop_seq;
+                ctx.for_loop_seq += 1;
+                ctx.add_local(&format!("__iter_ptr_{seq}"), IRType::Unknown);
+                ctx.add_local(&format!("__iter_idx_{seq}"), IRType::Int);
+                ctx.add_local(&format!("__iter_len_{seq}"), IRType::Int);
                 scan_and_allocate_locals(body, ctx);
                 if let Some(else_body) = else_body {
                     scan_and_allocate_locals(else_body, ctx);
@@ -474,9 +488,19 @@ pub fn compile_body(
                 // - loop_counter: current index in the list
                 // - list_length: length of the list
 
-                let iterator_ptr_idx = ctx.add_local("__iter_ptr", IRType::Unknown);
-                let loop_counter_idx = ctx.add_local("__iter_idx", IRType::Int);
-                let list_length_idx = ctx.add_local("__iter_len", IRType::Int);
+                // Reuse the iterator helper locals reserved for this loop during
+                // the scan, replaying the same sequence numbering.
+                let seq = ctx.for_loop_seq;
+                ctx.for_loop_seq += 1;
+                let iterator_ptr_idx = ctx
+                    .get_local_index(&format!("__iter_ptr_{seq}"))
+                    .expect("iterator ptr local not reserved");
+                let loop_counter_idx = ctx
+                    .get_local_index(&format!("__iter_idx_{seq}"))
+                    .expect("iterator idx local not reserved");
+                let list_length_idx = ctx
+                    .get_local_index(&format!("__iter_len_{seq}"))
+                    .expect("iterator len local not reserved");
                 let target_idx = ctx
                     .get_local_index(target)
                     .expect("Target variable not found");

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -779,8 +779,9 @@ pub fn compile_body(
                     }
                 }
 
-                // End of exception handling
-                func.instruction(&Instruction::End);
+                // Close the exception-dispatch if/else. Each typed handler opens
+                // and closes its own block, so only this `If` remains open here;
+                // a second `End` would close the function frame early.
                 func.instruction(&Instruction::End);
 
                 // If there's a finally block, always execute it

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -1,6 +1,6 @@
 use crate::compiler::context::{CompilationContext, SCRATCH_LOCALS};
 use crate::compiler::expression::{emit_expr, emit_integer_power_operation};
-use crate::ir::{IRBody, IRFunction, IROp, IRStatement, IRType, MemoryLayout};
+use crate::ir::{IRBody, IRConstant, IRExpr, IRFunction, IROp, IRStatement, IRType, MemoryLayout};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
 
 /// Compile an IR function into a WebAssembly function
@@ -22,34 +22,28 @@ pub fn compile_function(
     scan_and_allocate_locals(&ir_func.body, ctx);
 
     // Reserve scratch locals after all params and named locals so temporary
-    // calculations never clobber real variables. These indices are declared as
-    // i32 locals by the type-counting loop below (they are absent from
-    // locals_map, so get_local_type_by_index defaults them to i32).
+    // calculations never clobber real variables. The i32 scratch run is absent
+    // from locals_map (defaults to i32); the f64 scratch is registered so it is
+    // declared as f64 and used for operand juggling during int/float coercion.
     ctx.temp_local = ctx.local_count;
     ctx.local_count += SCRATCH_LOCALS;
+    ctx.temp_local_f64 = ctx.add_local("__f64_scratch", IRType::Float);
 
-    // Determine local types for WebAssembly
-    let mut locals = Vec::new();
+    // Declare locals in index order, coalescing adjacent same-type runs. The
+    // local index assigned by `add_local` must match the WASM declaration
+    // order, so grouping all i32s then all f64s (which reorders indices) is
+    // wrong once a function mixes int and float locals.
     let num_params = ir_func.params.len() as u32;
-
-    // Group locals by type
-    let mut i32_count = 0;
-    let mut f64_count = 0;
-
-    // Count locals by type (excluding parameters)
+    let mut locals: Vec<(u32, ValType)> = Vec::new();
     for i in num_params..ctx.local_count {
-        match get_local_type_by_index(ctx, i) {
-            IRType::Float => f64_count += 1,
-            _ => i32_count += 1,
+        let val_type = match get_local_type_by_index(ctx, i) {
+            IRType::Float => ValType::F64,
+            _ => ValType::I32,
+        };
+        match locals.last_mut() {
+            Some((count, last)) if *last == val_type => *count += 1,
+            _ => locals.push((1, val_type)),
         }
-    }
-
-    // Add locals to function signature
-    if i32_count > 0 {
-        locals.push((i32_count, ValType::I32));
-    }
-    if f64_count > 0 {
-        locals.push((f64_count, ValType::F64));
     }
 
     let mut func = Function::new(locals);
@@ -99,15 +93,52 @@ fn ensure_local(ctx: &mut CompilationContext, name: &str, var_type: IRType) {
     }
 }
 
+/// Best-effort type inference for an unannotated assignment value. Only used to
+/// decide a local's WASM value type (f64 vs i32), so it just needs to recognise
+/// float-producing expressions confidently; anything else is left `Unknown`
+/// (an i32 slot, which collections and pointers also use).
+fn infer_value_type(value: &IRExpr, ctx: &CompilationContext) -> IRType {
+    match value {
+        IRExpr::Const(IRConstant::Float(_)) => IRType::Float,
+        IRExpr::BinaryOp { left, right, .. } => {
+            if infer_value_type(left, ctx) == IRType::Float
+                || infer_value_type(right, ctx) == IRType::Float
+            {
+                IRType::Float
+            } else {
+                IRType::Unknown
+            }
+        }
+        IRExpr::UnaryOp { operand, .. } => infer_value_type(operand, ctx),
+        IRExpr::Variable(name) => ctx
+            .get_local_info(name)
+            .map(|info| info.var_type.clone())
+            .unwrap_or(IRType::Unknown),
+        IRExpr::FunctionCall { function_name, .. } if function_name == "float" => IRType::Float,
+        IRExpr::FunctionCall { function_name, .. } => ctx
+            .get_function_info(function_name)
+            .map(|f| f.return_type.clone())
+            .filter(|t| *t == IRType::Float)
+            .unwrap_or(IRType::Unknown),
+        _ => IRType::Unknown,
+    }
+}
+
 /// Scan the function body for variable declarations and allocate local variables
 pub fn scan_and_allocate_locals(body: &IRBody, ctx: &mut CompilationContext) {
     for stmt in &body.statements {
         match stmt {
             IRStatement::Assign {
-                target, var_type, ..
+                target,
+                var_type,
+                value,
             } => {
                 if ctx.get_local_index(target).is_none() {
-                    let var_type = var_type.clone().unwrap_or(IRType::Unknown);
+                    // Use the annotation if present; otherwise infer the type
+                    // from the value so unannotated float locals become f64.
+                    let var_type = var_type
+                        .clone()
+                        .unwrap_or_else(|| infer_value_type(value, ctx));
                     ctx.add_local(target, var_type);
                 }
             }

--- a/src/compiler/module.rs
+++ b/src/compiler/module.rs
@@ -1,4 +1,4 @@
-use crate::compiler::context::{ClassInfo, CompilationContext};
+use crate::compiler::context::{ClassInfo, CompilationContext, COLLECTION_HEAP_BASE};
 use crate::compiler::function::compile_function;
 use crate::ir::{IRModule, IRType};
 use std::collections::HashMap;
@@ -74,17 +74,6 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     }
     module.section(&functions);
 
-    // Memory section
-    let mut memories = MemorySection::new();
-    memories.memory(MemoryType {
-        minimum: 1,
-        maximum: Some(2),
-        memory64: false,
-        shared: false,
-        page_size_log2: None,
-    });
-    module.section(&memories);
-
     // Export section - export both functions and memory
     let mut exports = ExportSection::new();
 
@@ -147,8 +136,6 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     // Export memory
     exports.export("memory", wasm_encoder::ExportKind::Memory, 0);
 
-    module.section(&exports);
-
     // Data section for string constants
     let mut data = DataSection::new();
 
@@ -191,9 +178,26 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         }
     }
 
-    // The WASM spec requires the Code section (id 10) before the Data section
-    // (id 11); emitting Data first produces a module that strict validators
-    // (and Binaryen's reader) reject, which previously disabled optimization.
+    // Memory must hold the static data (strings/bytes/object instances) plus
+    // every collection region handed out during codegen. The collection heap
+    // grows from COLLECTION_HEAP_BASE, so size memory to cover its high-water
+    // mark (at least the base region).
+    let heap_end = COLLECTION_HEAP_BASE + ctx.collection_alloc_offset.get();
+    let min_pages = (((heap_end as u64) + 65535) / 65536).max(2);
+    let mut memories = MemorySection::new();
+    memories.memory(MemoryType {
+        minimum: min_pages,
+        maximum: None,
+        memory64: false,
+        shared: false,
+        page_size_log2: None,
+    });
+
+    // Section order follows the WASM spec: Memory (5), Export (7), Code (10),
+    // Data (11). Code must precede Data or strict validators (and Binaryen's
+    // reader) reject the module, which previously disabled optimization.
+    module.section(&memories);
+    module.section(&exports);
     module.section(&codes);
     module.section(&data);
 

--- a/src/compiler/module.rs
+++ b/src/compiler/module.rs
@@ -27,6 +27,11 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     // module; the compiler reuses that layout to emit loads and the data section.
     let memory_layout = ir_module.memory_layout.clone();
 
+    // Register module-level variables so functions can inline their values.
+    for var in &ir_module.variables {
+        ctx.add_module_var(&var.name, var.var_type.clone(), var.value.clone());
+    }
+
     // Build type section
     let mut types = TypeSection::new();
 

--- a/src/ir/converter.rs
+++ b/src/ir/converter.rs
@@ -1302,8 +1302,22 @@ pub fn lower_expr(expr: &Expr, memory_layout: &mut MemoryLayout) -> Result<IRExp
                     // Direct function call like func()
                     let function_name = name.id.to_string();
 
-                    // Type conversion functions like int, float, str
-                    let type_conversions = ["int", "float", "str", "bool"];
+                    // Numeric conversions int()/float() must actually convert,
+                    // so keep them as calls for the compiler to coerce. str()
+                    // and bool() currently pass the value through unchanged.
+                    if function_name == "int" || function_name == "float" {
+                        if call.args.len() != 1 {
+                            return Err(anyhow!(
+                                "Type conversion function expects exactly one argument"
+                            ));
+                        }
+                        let arg = lower_expr(&call.args[0], memory_layout)?;
+                        return Ok(IRExpr::FunctionCall {
+                            function_name,
+                            arguments: vec![arg],
+                        });
+                    }
+                    let type_conversions = ["str", "bool"];
                     if type_conversions.contains(&function_name.as_str()) {
                         if call.args.len() != 1 {
                             return Err(anyhow!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -843,4 +843,19 @@ mod collection_tests {
         let src = "def f() -> int:\n    result = 1.0\n    i = 0\n    while i < 10:\n        result = result * 2.0\n        i = i + 1\n    if result == 1024.0:\n        return 1\n    return 0\n";
         assert_eq!(call_i32(src, "f"), 1);
     }
+
+    #[test]
+    fn module_level_float_constant_is_inlined() {
+        // A module-level float constant used in arithmetic; emitting it at its
+        // natural type (not the caller's expectation) keeps it an f64.
+        let src = "PI = 2.5\ndef f() -> int:\n    if (PI * 4.0) == 10.0:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
+    }
+
+    #[test]
+    fn int_and_float_conversions() {
+        // int() truncates a float; float() widens an int.
+        let src = "def f() -> int:\n    return int(3.7) + int(float(2))\n";
+        assert_eq!(call_i32(src, "f"), 5);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -698,44 +698,77 @@ pub use crate::core::parser;
 mod collection_tests {
     use super::*;
 
-    /// Compile without optimization and fully validate the raw module. This
-    /// checks types and stack balance, catching the collection codegen bugs
-    /// (wrong element widths, untyped locals, and the stray drop after `print`)
+    use wasmi::{Engine, Linker, Module, Store};
+
+    /// Compile (unoptimized) and instantiate the module, returning the wasmi
+    /// instance + store so a test can call exported functions. Instantiation
+    /// validates types and stack balance, so this also guards the codegen bugs
     /// that previously produced invalid modules.
-    fn compiles_to_valid_wasm(source: &str) -> bool {
+    fn instantiate(source: &str) -> (wasmi::Instance, Store<()>) {
         let options = CompilerOptions {
             optimize: false,
             ..CompilerOptions::default()
         };
         let wasm = compile_python_to_wasm_with_options(source, &options).expect("compilation");
-        wasmparser::validate(&wasm).is_ok()
+        let engine = Engine::default();
+        let module = Module::new(&engine, &wasm[..]).expect("valid wasm module");
+        let mut store = Store::new(&engine, ());
+        let instance = Linker::<()>::new(&engine)
+            .instantiate(&mut store, &module)
+            .expect("instantiation")
+            .start(&mut store)
+            .expect("start");
+        (instance, store)
+    }
+
+    fn call_i32(source: &str, func: &str) -> i32 {
+        let (instance, mut store) = instantiate(source);
+        instance
+            .get_typed_func::<(), i32>(&store, func)
+            .expect("exported i32 fn")
+            .call(&mut store, ())
+            .expect("call")
     }
 
     #[test]
-    fn float_list_indexing_is_valid() {
-        assert!(compiles_to_valid_wasm(
-            "def f() -> float:\n    xs = [1.5, 2.5, 3.5]\n    return xs[1]\n"
-        ));
+    fn float_list_roundtrips() {
+        // Reads the float element back and compares (returns 1 on match). The
+        // value is stored as f32; 2.5 is exact, so equality holds.
+        let src = "def f() -> int:\n    xs = [1.5, 2.5, 3.5]\n    if xs[1] == 2.5:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
     }
 
     #[test]
-    fn float_tuple_indexing_is_valid() {
-        assert!(compiles_to_valid_wasm(
-            "def f() -> float:\n    t = (1.25, 2.75)\n    return t[1]\n"
-        ));
+    fn float_tuple_roundtrips() {
+        let src = "def f() -> int:\n    t = (1.25, 2.75)\n    if t[1] == 2.75:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
     }
 
     #[test]
-    fn int_list_indexing_is_valid() {
-        assert!(compiles_to_valid_wasm(
-            "def f() -> int:\n    xs = [10, 20, 30]\n    return xs[1]\n"
-        ));
+    fn int_list_indexing_returns_element() {
+        // Previously returned a constant 0: the untyped local lost its type.
+        let src = "def f() -> int:\n    xs = [10, 20, 30]\n    return xs[1]\n";
+        assert_eq!(call_i32(src, "f"), 20);
+    }
+
+    #[test]
+    fn distinct_collections_do_not_alias() {
+        // Both lists previously shared one address (base + local_count*100).
+        let src =
+            "def f() -> int:\n    a = [1, 2, 3]\n    b = [10, 20, 30]\n    return a[0] + b[0]\n";
+        assert_eq!(call_i32(src, "f"), 11);
+    }
+
+    #[test]
+    fn nested_collections_do_not_alias() {
+        let src = "def f() -> int:\n    m = [[1, 2], [3, 4]]\n    return m[0][1] + m[1][0]\n";
+        assert_eq!(call_i32(src, "f"), 5);
     }
 
     #[test]
     fn print_of_collection_element_is_valid() {
-        assert!(compiles_to_valid_wasm(
-            "def f():\n    xs = [1, 2, 3]\n    print(xs[0])\n"
-        ));
+        // print() returns nothing; a stray drop would underflow and fail to
+        // instantiate. Just ensure it builds and instantiates.
+        instantiate("def f():\n    xs = [1, 2, 3]\n    print(xs[0])\n");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,4 +771,23 @@ mod collection_tests {
         // instantiate. Just ensure it builds and instantiates.
         instantiate("def f():\n    xs = [1, 2, 3]\n    print(xs[0])\n");
     }
+
+    #[test]
+    fn range_for_loop_iterates() {
+        // for-over-range: previously the loop's iterator locals were added
+        // after the function's locals were fixed (out-of-range), and the range
+        // object's fields were stored with reversed operands, so the loop ran
+        // zero times. Sum 0..5 (with step) to exercise both.
+        let sum =
+            "def f() -> int:\n    t = 0\n    for i in range(5):\n        t = t + i\n    return t\n";
+        assert_eq!(call_i32(sum, "f"), 10);
+        let step = "def f() -> int:\n    t = 0\n    for i in range(0, 10, 2):\n        t = t + i\n    return t\n";
+        assert_eq!(call_i32(step, "f"), 20);
+    }
+
+    #[test]
+    fn nested_range_loops_use_distinct_iterators() {
+        let src = "def f() -> int:\n    s = 0\n    for i in range(3):\n        for j in range(4):\n            s = s + 1\n    return s\n";
+        assert_eq!(call_i32(src, "f"), 12);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,3 +693,49 @@ pub fn type_to_string(ir_type: &IRType) -> String {
 
 pub use crate::analysis::metadata::FunctionSignature;
 pub use crate::core::parser;
+
+#[cfg(test)]
+mod collection_tests {
+    use super::*;
+
+    /// Compile without optimization and fully validate the raw module. This
+    /// checks types and stack balance, catching the collection codegen bugs
+    /// (wrong element widths, untyped locals, and the stray drop after `print`)
+    /// that previously produced invalid modules.
+    fn compiles_to_valid_wasm(source: &str) -> bool {
+        let options = CompilerOptions {
+            optimize: false,
+            ..CompilerOptions::default()
+        };
+        let wasm = compile_python_to_wasm_with_options(source, &options).expect("compilation");
+        wasmparser::validate(&wasm).is_ok()
+    }
+
+    #[test]
+    fn float_list_indexing_is_valid() {
+        assert!(compiles_to_valid_wasm(
+            "def f() -> float:\n    xs = [1.5, 2.5, 3.5]\n    return xs[1]\n"
+        ));
+    }
+
+    #[test]
+    fn float_tuple_indexing_is_valid() {
+        assert!(compiles_to_valid_wasm(
+            "def f() -> float:\n    t = (1.25, 2.75)\n    return t[1]\n"
+        ));
+    }
+
+    #[test]
+    fn int_list_indexing_is_valid() {
+        assert!(compiles_to_valid_wasm(
+            "def f() -> int:\n    xs = [10, 20, 30]\n    return xs[1]\n"
+        ));
+    }
+
+    #[test]
+    fn print_of_collection_element_is_valid() {
+        assert!(compiles_to_valid_wasm(
+            "def f():\n    xs = [1, 2, 3]\n    print(xs[0])\n"
+        ));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -858,4 +858,19 @@ mod collection_tests {
         let src = "def f() -> int:\n    return int(3.7) + int(float(2))\n";
         assert_eq!(call_i32(src, "f"), 5);
     }
+
+    #[test]
+    fn min_and_max_reduce() {
+        // The reduction previously left the if/else stack unbalanced.
+        let src = "def lo() -> int:\n    return min(5, 3, 8, 1, 9)\ndef hi() -> int:\n    return max(5, 3, 8, 1, 9)\n";
+        assert_eq!(call_i32(src, "lo"), 1);
+        assert_eq!(call_i32(src, "hi"), 9);
+    }
+
+    #[test]
+    fn os_path_submodule_attribute_is_valid() {
+        // os.path.<attr> previously fell through to a stray drop that
+        // underflowed the stack; it now resolves the submodule attribute.
+        instantiate("import os\ndef f():\n    print(\"sep:\", os.path.sep)\n");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,6 +730,15 @@ mod collection_tests {
             .expect("call")
     }
 
+    fn call_i32_arg(source: &str, func: &str, arg: i32) -> i32 {
+        let (instance, mut store) = instantiate(source);
+        instance
+            .get_typed_func::<i32, i32>(&store, func)
+            .expect("exported i32 fn")
+            .call(&mut store, arg)
+            .expect("call")
+    }
+
     #[test]
     fn float_list_roundtrips() {
         // Reads the float element back and compares (returns 1 on match). The
@@ -789,5 +798,19 @@ mod collection_tests {
     fn nested_range_loops_use_distinct_iterators() {
         let src = "def f() -> int:\n    s = 0\n    for i in range(3):\n        for j in range(4):\n            s = s + 1\n    return s\n";
         assert_eq!(call_i32(src, "f"), 12);
+    }
+
+    #[test]
+    fn try_except_finally_is_valid_and_runs() {
+        // try/except/finally previously emitted an extra End that closed the
+        // function frame early ("body shorter than given size").
+        let src = "def f(x: int) -> int:\n    try:\n        return x + 1\n    except ValueError:\n        return -1\n    finally:\n        x = x + 100\n";
+        assert_eq!(call_i32_arg(src, "f", 5), 6);
+    }
+
+    #[test]
+    fn nested_try_except_is_valid() {
+        let src = "def f(x: int) -> int:\n    try:\n        try:\n            return x + 5\n        except KeyError:\n            return -2\n    except ValueError:\n        return -1\n";
+        assert_eq!(call_i32_arg(src, "f", 5), 10);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,4 +813,34 @@ mod collection_tests {
         let src = "def f(x: int) -> int:\n    try:\n        try:\n            return x + 5\n        except KeyError:\n            return -2\n    except ValueError:\n        return -1\n";
         assert_eq!(call_i32_arg(src, "f", 5), 10);
     }
+
+    #[test]
+    fn int_plus_float_coerces() {
+        // a (int) + b (float) widens the int to f64; the result equals 3.5.
+        let src = "def f() -> int:\n    a = 2\n    b = 1.5\n    if (a + b) == 3.5:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
+    }
+
+    #[test]
+    fn boolean_and_or_short_circuit() {
+        // and/or now yield an i32 result from their if/else instead of an
+        // empty block type.
+        let and =
+            "def f(a: int) -> int:\n    if (a > 0) and (a < 10):\n        return 1\n    return 0\n";
+        assert_eq!(call_i32_arg(and, "f", 5), 1);
+        assert_eq!(call_i32_arg(and, "f", 20), 0);
+        let or =
+            "def f(a: int) -> int:\n    if (a < 0) or (a > 100):\n        return 1\n    return 0\n";
+        assert_eq!(call_i32_arg(or, "f", -1), 1);
+        assert_eq!(call_i32_arg(or, "f", 50), 0);
+    }
+
+    #[test]
+    fn unannotated_float_local_in_mixed_function() {
+        // `result` is an unannotated float local (f64) living alongside the int
+        // local `i`; both the type inference and index-order local layout must
+        // be right for this to validate and compute 2**10.
+        let src = "def f() -> int:\n    result = 1.0\n    i = 0\n    while i < 10:\n        result = result * 2.0\n        i = i + 1\n    if result == 1024.0:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
+    }
 }

--- a/src/stdlib/mod.rs
+++ b/src/stdlib/mod.rs
@@ -48,6 +48,14 @@ pub fn is_stdlib_submodule(module: &str, submodule: &str) -> bool {
     matches!((module, submodule), ("os", "path"))
 }
 
+/// Resolve an attribute on a stdlib submodule, e.g. `os.path.sep`.
+pub fn get_submodule_attribute(module: &str, submodule: &str, attr: &str) -> Option<StdlibValue> {
+    match (module, submodule) {
+        ("os", "path") => os::path::get_attribute(attr),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum StdlibValue {
     Int(i32),


### PR DESCRIPTION
## Summary

A batch of WebAssembly codegen fixes so collections, floats, `range` loops, `try/except`, and several builtins/stdlib features compile to valid WASM and run correctly. Example suite goes to **19/23 passing**; newly fixed: `range_example`, `exceptions`, `builtins`, `test_system_calls`, `typed_demo`.

## Changes

- Collections each get their own memory region (compile-time bump allocator) — distinct and nested literals no longer alias (Refs #14)
- Float list/tuple elements round-trip (f32 slots); untyped collection locals keep their element type
- `for … in range(...)` iterates (ascending); `try/except/finally` balances
- Numeric typing: `and`/`or` return i32, mixed int/float coercion, float-local inference, index-order local layout
- Module-level variables resolve in functions; `int()`/`float()` convert; `min()`/`max()` reduce; `os.path.*` attributes resolve

## Testing

`just ci` green — 36 tests including ~17 that execute compiled modules via `wasmi` and assert return values. All examples checked with `wasm-validate`; no regressions.

## Known gaps

Descending ranges, string/bytes locals (`len`/`bytes_example`), class+float (`module_level_demo`), and a Binaryen crash on `test_math`/`stdlib_all_modules` remain — diagnosed, out of scope here.

## Related

Refs #14
