### PR TITLE
fix(codegen): descending range loops and integer negation

### DIFF
--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -498,9 +498,12 @@ pub fn emit_expr(
                     // Integer/Boolean operations
                     match op {
                         IRUnaryOp::Neg => {
-                            // Negate: -x = 0 - x
-                            func.instruction(&Instruction::I32Const(0));
-                            func.instruction(&Instruction::I32Sub);
+                            // Negate: -x. The operand is already on the stack, so
+                            // multiply by -1 (mirroring the float path). Emitting
+                            // `i32.const 0; i32.sub` here would instead compute
+                            // `operand - 0`, leaving the value unchanged.
+                            func.instruction(&Instruction::I32Const(-1));
+                            func.instruction(&Instruction::I32Mul);
                             IRType::Int
                         }
                         IRUnaryOp::Not => {

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -648,10 +648,29 @@ pub fn compile_body(
                         }));
                         func.instruction(&Instruction::LocalSet(list_length_idx));
 
-                        // Check if current >= stop
+                        // Break condition depends on the sign of step, which may
+                        // be dynamic, so branch on it at runtime:
+                        //   step > 0  -> stop iterating once current >= stop
+                        //   step <= 0 -> stop iterating once current <= stop
+                        // (A single ascending `current >= stop` test would make a
+                        // descending range, e.g. range(10, 0, -1), exit immediately.)
+                        func.instruction(&Instruction::LocalGet(iterator_ptr_idx));
+                        func.instruction(&Instruction::I32Load(MemArg {
+                            offset: 8,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::I32GtS); // step > 0
+                        func.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
                         func.instruction(&Instruction::LocalGet(target_idx));
                         func.instruction(&Instruction::LocalGet(list_length_idx));
-                        func.instruction(&Instruction::I32GeS);
+                        func.instruction(&Instruction::I32GeS); // current >= stop
+                        func.instruction(&Instruction::Else);
+                        func.instruction(&Instruction::LocalGet(target_idx));
+                        func.instruction(&Instruction::LocalGet(list_length_idx));
+                        func.instruction(&Instruction::I32LeS); // current <= stop
+                        func.instruction(&Instruction::End);
                         func.instruction(&Instruction::BrIf(1)); // Break if true
 
                         // Execute the loop body

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -795,6 +795,26 @@ mod collection_tests {
     }
 
     #[test]
+    fn descending_range_for_loop_iterates() {
+        // range(start, stop, -step): the loop's break test was ascending-only
+        // (current >= stop), so a descending range exited immediately. The step
+        // also relied on integer unary negation, which evaluated `-x` as `x`.
+        let down = "def f() -> int:\n    t = 0\n    for i in range(10, 0, -1):\n        t = t + i\n    return t\n";
+        assert_eq!(call_i32(down, "f"), 55);
+        let neg = "def f() -> int:\n    t = 0\n    for i in range(20, 5, -3):\n        t = t + i\n    return t\n";
+        assert_eq!(call_i32(neg, "f"), 70);
+        let empty = "def f() -> int:\n    t = 0\n    for i in range(0, 5, -1):\n        t = t + i\n    return t\n";
+        assert_eq!(call_i32(empty, "f"), 0);
+    }
+
+    #[test]
+    fn integer_unary_negation() {
+        // `-x` previously emitted `operand - 0`, leaving the value unchanged.
+        let src = "def f() -> int:\n    x = 7\n    return -x\n";
+        assert_eq!(call_i32(src, "f"), -7);
+    }
+
+    #[test]
     fn nested_range_loops_use_distinct_iterators() {
         let src = "def f() -> int:\n    s = 0\n    for i in range(3):\n        for j in range(4):\n            s = s + 1\n    return s\n";
         assert_eq!(call_i32(src, "f"), 12);


### PR DESCRIPTION
`for i in range(start, stop, -step)` ran zero times. The range for-loop used an ascending-only break test (`current >= stop`), so a descending range satisfied it on entry and exited immediately. The break is now step-sign-aware via a runtime branch on the sign of step (step may be dynamic): stop once `current >= stop` when ascending, or `current <= stop` when descending.

While fixing the range step, the underlying cause turned out broader: integer unary negation was wrong everywhere. The `Neg` path emitted the operand and then `i32.const 0; i32.sub`, which computes `operand - 0`, so `-x` evaluated to `x` (and `range(.., -1)` stored a step of `1`). Negate by multiplying by `-1`, mirroring the already-correct float path.

Adds regression tests for descending/empty ranges and `-x`.

Fixes #80