### PR TITLE
fix(codegen): round-trip string/bytes locals and slicing

### DIFF
--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -14,6 +14,14 @@ pub const SCRATCH_LOCALS: u32 = 8;
 /// literals never overlap them.
 pub const COLLECTION_HEAP_BASE: u32 = 131072;
 
+/// Name of the companion local that holds the length of a string/bytes local.
+/// A string/bytes value is an `(offset, length)` pair but a WASM local holds a
+/// single word, so the offset lives in the named local and the length in this
+/// companion. See the string/bytes handling in assignment and variable reads.
+pub fn strlen_local_name(name: &str) -> String {
+    format!("__strlen_{name}")
+}
+
 /// Local variable
 pub struct LocalInfo {
     pub index: u32,

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -1,4 +1,4 @@
-use crate::compiler::context::CompilationContext;
+use crate::compiler::context::{strlen_local_name, CompilationContext};
 use crate::ir::{IRBoolOp, IRCompareOp, IRConstant, IRExpr, IROp, IRType, IRUnaryOp, MemoryLayout};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
 
@@ -138,8 +138,18 @@ pub fn emit_expr(
         }
         IRExpr::Param(name) | IRExpr::Variable(name) => {
             if let Some(local_info) = ctx.get_local_info(name) {
-                func.instruction(&Instruction::LocalGet(local_info.index));
-                local_info.var_type.clone()
+                let index = local_info.index;
+                let var_type = local_info.var_type.clone();
+                func.instruction(&Instruction::LocalGet(index));
+                // String/bytes locals hold only the offset; push the length from
+                // the companion local to rebuild the (offset, length) pair the
+                // rest of the pipeline expects.
+                if matches!(var_type, IRType::String | IRType::Bytes) {
+                    if let Some(len_idx) = ctx.get_local_index(&strlen_local_name(name)) {
+                        func.instruction(&Instruction::LocalGet(len_idx));
+                    }
+                }
+                var_type
             } else if let Some((declared, value)) = ctx.get_module_var(name) {
                 // Module-level variable: inline its initializer. Clone first so
                 // the recursive emit does not alias the borrow of `ctx`. Emit at
@@ -776,8 +786,11 @@ pub fn emit_expr(
                         }
                         match &arg_types[0] {
                             IRType::String | IRType::Bytes => {
-                                // (offset, length) on stack; pop offset, keep length
+                                // (offset, length) on stack with length on top.
+                                // Keep the length, discard the offset below it.
+                                func.instruction(&Instruction::LocalSet(ctx.temp_local));
                                 func.instruction(&Instruction::Drop);
+                                func.instruction(&Instruction::LocalGet(ctx.temp_local));
                                 IRType::Int
                             }
                             // Lists, dicts, sets and tuples are all pointers that
@@ -804,8 +817,8 @@ pub fn emit_expr(
                         // Pop the arguments off the stack
                         for arg_type in &arg_types {
                             match arg_type {
-                                IRType::String => {
-                                    // Strings are (offset, length), drop both
+                                IRType::String | IRType::Bytes => {
+                                    // Strings/bytes are (offset, length), drop both
                                     func.instruction(&Instruction::Drop);
                                     func.instruction(&Instruction::Drop);
                                 }
@@ -1388,135 +1401,100 @@ pub fn emit_expr(
 
             match container_type {
                 IRType::String | IRType::Bytes => {
-                    // String/Bytes slicing: str[start:end] or bytes[start:end]
-                    // Stack initially: (offset, length)
-                    // Result: (new_offset, new_length)
+                    // String/Bytes slicing: str[start:end] / bytes[start:end].
+                    // Entry stack: (offset, length). Result: (new_offset,
+                    // new_length) into the same backing memory.
+                    //
+                    // The clamping is fully branchless (i32 `select`), with all
+                    // operands held in locals. An earlier version used
+                    // `If(BlockType::Empty)` blocks that consumed values pushed
+                    // before the block (a net-nonzero stack effect), which failed
+                    // WASM validation.
+                    let off = ctx.temp_local + 5;
+                    let len = ctx.temp_local + 6;
+                    let lo = ctx.temp_local + 2;
+                    let hi = ctx.temp_local + 3;
+                    let scratch = ctx.temp_local + 4;
 
-                    // Save length to temp local
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local));
+                    // Stash (offset, length) into high locals first so any nested
+                    // start/end expression (which may use the low scratch locals)
+                    // cannot clobber them.
+                    func.instruction(&Instruction::LocalSet(len));
+                    func.instruction(&Instruction::LocalSet(off));
 
-                    // Stack: (offset)
-                    // Evaluate start, defaulting to 0
+                    // start, defaulting to 0
                     if let Some(s) = start {
                         emit_expr(s, func, ctx, memory_layout, Some(&IRType::Int));
                     } else {
                         func.instruction(&Instruction::I32Const(0));
-                    };
+                    }
+                    func.instruction(&Instruction::LocalSet(lo));
 
-                    // Stack: (offset, start)
-                    // Evaluate end, defaulting to length
+                    // end, defaulting to length
                     if let Some(e) = end {
                         emit_expr(e, func, ctx, memory_layout, Some(&IRType::Int));
                     } else {
-                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::LocalGet(len));
+                    }
+                    func.instruction(&Instruction::LocalSet(hi));
+
+                    // Normalize negatives and clamp each bound to [0, length].
+                    // `select` pops (v1, v2, cond) and yields v1 when cond != 0.
+                    let normalize_and_clamp = |func: &mut Function, bound: u32| {
+                        // bound = bound < 0 ? bound + length : bound
+                        func.instruction(&Instruction::LocalGet(bound));
+                        func.instruction(&Instruction::LocalGet(len));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalGet(bound));
+                        func.instruction(&Instruction::LocalGet(bound));
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::I32LtS);
+                        func.instruction(&Instruction::Select);
+                        func.instruction(&Instruction::LocalSet(bound));
+                        // bound = max(bound, 0)
+                        func.instruction(&Instruction::LocalGet(bound));
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::LocalGet(bound));
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::I32GtS);
+                        func.instruction(&Instruction::Select);
+                        func.instruction(&Instruction::LocalSet(bound));
+                        // bound = min(bound, length)
+                        func.instruction(&Instruction::LocalGet(bound));
+                        func.instruction(&Instruction::LocalGet(len));
+                        func.instruction(&Instruction::LocalGet(bound));
+                        func.instruction(&Instruction::LocalGet(len));
+                        func.instruction(&Instruction::I32LtS);
+                        func.instruction(&Instruction::Select);
+                        func.instruction(&Instruction::LocalSet(bound));
                     };
+                    normalize_and_clamp(func, lo);
+                    normalize_and_clamp(func, hi);
 
-                    // Stack: (offset, start, end)
-                    // Save end for later
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local + 1));
-
-                    // Stack: (offset, start)
-                    // Handle negative start index: if start < 0, add length
-                    func.instruction(&Instruction::LocalTee(ctx.temp_local + 2));
-                    func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::I32LtS);
-                    func.instruction(&Instruction::If(BlockType::Empty));
-                    // start is negative, so add length
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32Add);
-                    func.instruction(&Instruction::End);
-
-                    // Stack: (offset, normalized_start)
-                    // Clamp start to [0, length]
-                    func.instruction(&Instruction::LocalTee(ctx.temp_local + 2));
-                    func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::I32LtS);
-                    func.instruction(&Instruction::If(BlockType::Empty));
-                    func.instruction(&Instruction::Drop);
-                    func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::Else);
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32GtS);
-                    func.instruction(&Instruction::If(BlockType::Empty));
-                    func.instruction(&Instruction::Drop);
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::End);
-                    func.instruction(&Instruction::End);
-
-                    // Stack: (offset, clamped_start)
-                    // Handle end index
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
-
-                    // Stack: (offset, start, end)
-                    // Handle negative end index: if end < 0, add length
-                    func.instruction(&Instruction::LocalTee(ctx.temp_local + 2));
-                    func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::I32LtS);
-                    func.instruction(&Instruction::If(BlockType::Empty));
-                    // end is negative, so add length
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32Add);
-                    func.instruction(&Instruction::End);
-
-                    // Stack: (offset, start, normalized_end)
-                    // Clamp end to [0, length]
-                    func.instruction(&Instruction::LocalTee(ctx.temp_local + 2));
-                    func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::I32LtS);
-                    func.instruction(&Instruction::If(BlockType::Empty));
-                    func.instruction(&Instruction::Drop);
-                    func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::Else);
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::I32GtS);
-                    func.instruction(&Instruction::If(BlockType::Empty));
-                    func.instruction(&Instruction::Drop);
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::End);
-                    func.instruction(&Instruction::End);
-
-                    // Stack: (offset, start, end)
-                    // Ensure start <= end for proper slice_length
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local + 1));
-
-                    // Stack: (offset, start)
-                    // Calculate slice_length = end - start
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
+                    // new_length = max(hi - lo, 0)
+                    func.instruction(&Instruction::LocalGet(hi));
+                    func.instruction(&Instruction::LocalGet(lo));
                     func.instruction(&Instruction::I32Sub);
-
-                    // Stack: (offset, start, slice_length)
-                    // Ensure slice_length >= 0
-                    func.instruction(&Instruction::LocalTee(ctx.temp_local + 3));
+                    func.instruction(&Instruction::LocalTee(scratch));
                     func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::I32LtS);
-                    func.instruction(&Instruction::If(BlockType::Empty));
-                    func.instruction(&Instruction::Drop);
+                    func.instruction(&Instruction::LocalGet(scratch));
                     func.instruction(&Instruction::I32Const(0));
-                    func.instruction(&Instruction::End);
+                    func.instruction(&Instruction::I32GtS);
+                    func.instruction(&Instruction::Select);
+                    func.instruction(&Instruction::LocalSet(scratch));
 
-                    // Stack: (offset, start, clamped_slice_length)
-                    // Swap to get offset and slice_length for final result
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local + 3));
-
-                    // Stack: (offset, start)
-                    // Calculate new_offset = offset + start
-                    func.instruction(&Instruction::I32Add);
-
-                    // Stack: (new_offset)
-                    // Push new_length
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
-
-                    // Stack: (new_offset, new_length)
-                    // TODO: Handle step parameter properly
-                    // For now, ignore step (default step=1)
-                    if let Some(_s) = step {
-                        // Drop step value if provided
-                        emit_expr(_s, func, ctx, memory_layout, Some(&IRType::Int));
+                    // Step is not yet honoured (default step=1); evaluate and
+                    // discard it so a provided step doesn't unbalance the stack.
+                    if let Some(s) = step {
+                        emit_expr(s, func, ctx, memory_layout, Some(&IRType::Int));
                         func.instruction(&Instruction::Drop);
                     }
+
+                    // Result: (new_offset = offset + lo, new_length)
+                    func.instruction(&Instruction::LocalGet(off));
+                    func.instruction(&Instruction::LocalGet(lo));
+                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalGet(scratch));
 
                     container_type.clone()
                 }

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -1,4 +1,4 @@
-use crate::compiler::context::{CompilationContext, SCRATCH_LOCALS};
+use crate::compiler::context::{strlen_local_name, CompilationContext, SCRATCH_LOCALS};
 use crate::compiler::expression::{emit_expr, emit_integer_power_operation};
 use crate::ir::{IRBody, IRConstant, IRExpr, IRFunction, IROp, IRStatement, IRType, MemoryLayout};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
@@ -93,23 +93,41 @@ fn ensure_local(ctx: &mut CompilationContext, name: &str, var_type: IRType) {
     }
 }
 
-/// Best-effort type inference for an unannotated assignment value. Only used to
-/// decide a local's WASM value type (f64 vs i32), so it just needs to recognise
-/// float-producing expressions confidently; anything else is left `Unknown`
-/// (an i32 slot, which collections and pointers also use).
+/// Best-effort type inference for an unannotated assignment value. Used to
+/// decide a local's WASM value type (f64 vs i32) and to recognise string/bytes
+/// locals so a companion length local can be reserved for them. It only needs
+/// to recognise float- and string/bytes-producing expressions confidently;
+/// anything else is left `Unknown` (an i32 slot, which collections and pointers
+/// also use).
 fn infer_value_type(value: &IRExpr, ctx: &CompilationContext) -> IRType {
     match value {
         IRExpr::Const(IRConstant::Float(_)) => IRType::Float,
-        IRExpr::BinaryOp { left, right, .. } => {
-            if infer_value_type(left, ctx) == IRType::Float
-                || infer_value_type(right, ctx) == IRType::Float
-            {
+        IRExpr::Const(IRConstant::String(_)) => IRType::String,
+        IRExpr::Const(IRConstant::Bytes(_)) => IRType::Bytes,
+        IRExpr::BinaryOp { left, right, op } => {
+            let lt = infer_value_type(left, ctx);
+            let rt = infer_value_type(right, ctx);
+            if lt == IRType::Float || rt == IRType::Float {
                 IRType::Float
+            } else if matches!(op, IROp::Add) && matches!(lt, IRType::String | IRType::Bytes) {
+                // String/bytes concatenation yields the same kind.
+                lt
             } else {
                 IRType::Unknown
             }
         }
         IRExpr::UnaryOp { operand, .. } => infer_value_type(operand, ctx),
+        // Slicing a string/bytes yields the same kind; indexing a string yields
+        // a one-character string (bytes/list indexing yields a scalar).
+        IRExpr::Slicing { container, .. } => match infer_value_type(container, ctx) {
+            t @ (IRType::String | IRType::Bytes) => t,
+            _ => IRType::Unknown,
+        },
+        IRExpr::Indexing { container, .. }
+            if infer_value_type(container, ctx) == IRType::String =>
+        {
+            IRType::String
+        }
         IRExpr::Variable(name) => ctx
             .get_local_info(name)
             .map(|info| info.var_type.clone())
@@ -139,7 +157,18 @@ pub fn scan_and_allocate_locals(body: &IRBody, ctx: &mut CompilationContext) {
                     let var_type = var_type
                         .clone()
                         .unwrap_or_else(|| infer_value_type(value, ctx));
+                    // String/bytes locals carry an (offset, length) pair, so they
+                    // need a companion local for the length. Reserve one for
+                    // `Unknown` locals too: a stdlib call like `os.path.join`
+                    // infers as `Unknown` here but is upgraded to `String` during
+                    // codegen, and the companion can't be added after the local
+                    // vector is fixed.
+                    let needs_companion =
+                        matches!(var_type, IRType::String | IRType::Bytes | IRType::Unknown);
                     ctx.add_local(target, var_type);
+                    if needs_companion {
+                        ctx.add_local(&strlen_local_name(target), IRType::Int);
+                    }
                 }
             }
             IRStatement::TupleUnpack { targets, .. } => {
@@ -280,11 +309,23 @@ pub fn compile_body(
                                 | IRType::Bytes
                         )
                     {
-                        info.var_type = value_type;
+                        info.var_type = value_type.clone();
                     }
                 }
 
                 if let Some(local_idx) = ctx.get_local_index(target) {
+                    // A string/bytes value is an (offset, length) pair with the
+                    // length on top of the stack. Store the length into the
+                    // companion local first, then the offset into the named one.
+                    if matches!(value_type, IRType::String | IRType::Bytes) {
+                        match ctx.get_local_index(&strlen_local_name(target)) {
+                            Some(len_idx) => func.instruction(&Instruction::LocalSet(len_idx)),
+                            // No companion was reserved (inference missed this
+                            // string local); drop the length to keep the stack
+                            // balanced rather than leaving it stranded.
+                            None => func.instruction(&Instruction::Drop),
+                        };
+                    }
                     func.instruction(&Instruction::LocalSet(local_idx));
                 } else {
                     // Handle the case where the variable is not found in the context

--- a/src/compiler/module.rs
+++ b/src/compiler/module.rs
@@ -141,30 +141,45 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     // Export memory
     exports.export("memory", wasm_encoder::ExportKind::Memory, 0);
 
-    // Data section for string constants
+    // Data section for string and bytes constants.
     let mut data = DataSection::new();
 
-    // Add string data to memory
+    // String data lives from offset 0. Offsets are assigned sequentially as
+    // `len + 1` (a null terminator after each), so emitting the strings in
+    // offset order, each followed by a NUL, reproduces those exact offsets.
     if !memory_layout.string_offsets.is_empty() {
-        let mut all_strings = Vec::new();
-
-        // Sort strings by offset to maintain order
-        let mut offsets: Vec<(String, u32)> = memory_layout
+        let mut offsets: Vec<(&String, u32)> = memory_layout
             .string_offsets
             .iter()
-            .map(|(s, &offset)| (s.clone(), offset))
+            .map(|(s, &offset)| (s, offset))
             .collect();
-
         offsets.sort_by_key(|(_s, offset)| *offset);
 
-        // Concatenate all strings with null terminators
+        let mut all_strings = Vec::new();
         for (s, _) in offsets {
             all_strings.extend_from_slice(s.as_bytes());
             all_strings.push(0); // Null terminator
         }
-
-        // Create an active data segment at offset 0
         data.active(0, &ConstExpr::i32_const(0), all_strings);
+    }
+
+    // Bytes data lives from `next_bytes_offset`'s base (32768). Offsets advance
+    // by exactly the byte length (no terminator), so the values are contiguous
+    // from the lowest assigned offset; emit them in offset order from there.
+    if !memory_layout.bytes_offsets.is_empty() {
+        let mut offsets: Vec<(&Vec<u8>, u32)> = memory_layout
+            .bytes_offsets
+            .iter()
+            .map(|(b, &offset)| (b, offset))
+            .collect();
+        offsets.sort_by_key(|(_b, offset)| *offset);
+
+        let base = offsets[0].1;
+        let mut all_bytes = Vec::new();
+        for (b, _) in offsets {
+            all_bytes.extend_from_slice(b);
+        }
+        data.active(0, &ConstExpr::i32_const(base as i32), all_bytes);
     }
 
     // Code section

--- a/src/ir/converter.rs
+++ b/src/ir/converter.rs
@@ -1717,6 +1717,35 @@ pub fn lower_expr(expr: &Expr, memory_layout: &mut MemoryLayout) -> Result<IRExp
             Ok(IRExpr::DictLiteral(pairs))
         }
         Expr::Subscript(subscript) => {
+            // A plain `x[a:b:c]` parses as an `Expr::Slice` (lower/upper/step),
+            // distinct from the extended `Expr::Tuple` form handled below.
+            if let Expr::Slice(slice_expr) = &*subscript.slice {
+                let lower = slice_expr
+                    .lower
+                    .as_ref()
+                    .map(|e| lower_expr(e, memory_layout))
+                    .transpose()?
+                    .map(Box::new);
+                let upper = slice_expr
+                    .upper
+                    .as_ref()
+                    .map(|e| lower_expr(e, memory_layout))
+                    .transpose()?
+                    .map(Box::new);
+                let step = slice_expr
+                    .step
+                    .as_ref()
+                    .map(|e| lower_expr(e, memory_layout))
+                    .transpose()?
+                    .map(Box::new);
+                return Ok(IRExpr::Slicing {
+                    container: Box::new(lower_expr(&subscript.value, memory_layout)?),
+                    start: lower,
+                    end: upper,
+                    step,
+                });
+            }
+
             // Check if this is a slice expression (start:end:step)
             // In rustpython, slices are represented as Tuple expressions with None for missing bounds
             if let Expr::Tuple(tuple_expr) = &*subscript.slice {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -801,6 +801,51 @@ mod collection_tests {
     }
 
     #[test]
+    fn bytes_local_round_trips() {
+        // A string/bytes value is an (offset, length) pair, but a local holds
+        // one word; without a companion length local the offset was dropped, so
+        // indexing read from offset 0 and len() returned 0.
+        let idx = "def f() -> int:\n    b = b\"hello\"\n    return b[0]\n";
+        assert_eq!(call_i32(idx, "f"), 104); // 'h'
+        let idx1 = "def f() -> int:\n    b = b\"hello\"\n    return b[1]\n";
+        assert_eq!(call_i32(idx1, "f"), 101); // 'e'
+        let length = "def f() -> int:\n    b = b\"hello\"\n    return len(b)\n";
+        assert_eq!(call_i32(length, "f"), 5);
+    }
+
+    #[test]
+    fn string_local_len() {
+        // len() of a string local previously kept the offset, not the length.
+        let src = "def f() -> int:\n    s = \"hello\"\n    return len(s)\n";
+        assert_eq!(call_i32(src, "f"), 5);
+    }
+
+    #[test]
+    fn bytes_slicing_round_trips() {
+        // `Expr::Slice` now lowers, and the slice codegen is branchless so it
+        // validates. Slices share the source bytes' backing memory.
+        let mid = "def f() -> int:\n    b = b\"hello\"\n    s = b[1:4]\n    return s[0]\n";
+        assert_eq!(call_i32(mid, "f"), 101); // b"ell"[0] == 'e'
+        let mid_len = "def f() -> int:\n    b = b\"hello\"\n    s = b[1:4]\n    return len(s)\n";
+        assert_eq!(call_i32(mid_len, "f"), 3);
+        let open_end = "def f() -> int:\n    b = b\"hello\"\n    return len(b[2:])\n";
+        assert_eq!(call_i32(open_end, "f"), 3);
+        let open_start = "def f() -> int:\n    b = b\"hello\"\n    return len(b[:3])\n";
+        assert_eq!(call_i32(open_start, "f"), 3);
+        let negative = "def f() -> int:\n    b = b\"hello\"\n    s = b[-2:]\n    return s[0]\n";
+        assert_eq!(call_i32(negative, "f"), 108); // b"lo"[0] == 'l'
+    }
+
+    #[test]
+    fn bytes_concatenation_round_trips() {
+        let src =
+            "def f() -> int:\n    a = b\"ab\"\n    c = b\"cd\"\n    d = a + c\n    return d[3]\n";
+        assert_eq!(call_i32(src, "f"), 100); // 'd'
+        let len = "def f() -> int:\n    a = b\"ab\"\n    c = b\"cd\"\n    return len(a + c)\n";
+        assert_eq!(call_i32(len, "f"), 4);
+    }
+
+    #[test]
     fn try_except_finally_is_valid_and_runs() {
         // try/except/finally previously emitted an extra End that closed the
         // function frame early ("body shorter than given size").


### PR DESCRIPTION
`bytes_example.py` failed to compile, and string/bytes values did not survive being stored in a local. A string/bytes value is an `(offset, length)` pair, but a WASM local holds a single word, so the offset was dropped on assignment: `b[0]` indexed from offset 0 and `len(b)` returned 0. Each string/bytes local now carries a companion length local, so the pair round-trips through assignment and reads while the rest of the pipeline keeps using the two-word form.

Several related gaps surfaced while making the example work end to end:

- Bytes constants were never written to the data section (only strings were), so even a constant `b"hi"[0]` read uninitialised memory. The data section now emits a bytes segment at the bytes base (32768).
- `len()` of a string/bytes dropped the length and kept the offset; it now keeps the length.
- A plain `x[a:b]` parses as `Expr::Slice`, which was unhandled by the lowering (only the extended `Expr::Tuple` slice form was). It now lowers to `IRExpr::Slicing`.
- The string/bytes slice-clamp codegen used `If(BlockType::Empty)` blocks that consumed operands pushed before the block (a net-nonzero stack effect), which failed WASM validation. It is rewritten to be branchless (`select`) with all operands held in locals.

A companion length local is also reserved for `Unknown` locals, since a stdlib call such as `os.path.join` infers as `Unknown` during the local scan but is upgraded to `String` during codegen — without the companion, its reads pushed one word while `print` consumed two, underflowing the stack (regressed `test_system_calls.py`).

Adds round-trip tests for bytes indexing, string/bytes `len`, slicing (including open-ended and negative bounds), and concatenation.

Fixes #81