### PR TITLE
fix(codegen): float-aware classes and constructor arg coercion

### DIFF
--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -34,6 +34,8 @@ pub struct ClassInfo {
     pub name: String,
     pub methods: HashMap<String, u32>, // method_name -> function_index
     pub field_offsets: HashMap<String, u64>, // field_name -> byte_offset
+    pub field_types: HashMap<String, IRType>, // field_name -> value type (f64 vs i32)
+    pub class_var_values: HashMap<String, IRExpr>, // class-level var name -> initializer
     pub instance_size: u32,            // size of instance in bytes
 }
 

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -1,4 +1,5 @@
 use crate::compiler::context::CompilationContext;
+use crate::compiler::function::{load_field_instr, lookup_field};
 use crate::ir::{IRBoolOp, IRCompareOp, IRConstant, IRExpr, IROp, IRType, IRUnaryOp, MemoryLayout};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
 
@@ -70,8 +71,15 @@ pub fn emit_expr(
         IRExpr::Const(constant) => {
             match constant {
                 IRConstant::Int(i) => {
-                    func.instruction(&Instruction::I32Const(*i));
-                    IRType::Int
+                    // Widen to f64 when a float is expected (e.g. an int literal
+                    // passed to a float parameter or stored in a float field).
+                    if let Some(IRType::Float) = expected_type {
+                        func.instruction(&Instruction::F64Const(f64_const(*i as f64)));
+                        IRType::Float
+                    } else {
+                        func.instruction(&Instruction::I32Const(*i));
+                        IRType::Int
+                    }
                 }
                 IRConstant::Float(f) => {
                     func.instruction(&Instruction::F64Const(f64_const(*f)));
@@ -158,7 +166,11 @@ pub fn emit_expr(
         }
         IRExpr::BinaryOp { left, right, op } => {
             let left_type = emit_expr(left, func, ctx, memory_layout, None);
-            let right_type = emit_expr(right, func, ctx, memory_layout, Some(&left_type));
+            // Emit the right operand at its natural type rather than forcing it to
+            // the left's type: a float right operand under an int left (e.g.
+            // `2 * (a_float + b_float)`) must not be truncated to int — the
+            // int/float widening below promotes whichever side is the integer.
+            let right_type = emit_expr(right, func, ctx, memory_layout, None);
 
             // Handle string and bytes operations
             if left_type == IRType::String || left_type == IRType::Bytes {
@@ -727,40 +739,51 @@ pub fn emit_expr(
             function_name,
             arguments,
         } => {
+            // Class instantiation: `ClassName(args)`. Handled before the generic
+            // argument emission so the instance pointer (`self`) is the first
+            // argument to `__init__` and the user arguments are coerced to their
+            // declared parameter types (e.g. int literals widened to f64).
+            if ctx.get_class_info(function_name).is_some() {
+                let instance_ptr = 65536
+                    + ctx
+                        .get_class_info(function_name)
+                        .map(|c| c.instance_size)
+                        .unwrap_or(0);
+                let init_idx = ctx
+                    .get_class_info(function_name)
+                    .and_then(|c| c.methods.get("__init__").copied());
+
+                if let Some(init_idx) = init_idx {
+                    // __init__ parameter types, `self` first.
+                    let param_types: Vec<IRType> = ctx
+                        .get_function_info(&format!("{function_name}::__init__"))
+                        .map(|f| f.param_types.clone())
+                        .unwrap_or_default();
+                    func.instruction(&Instruction::I32Const(instance_ptr as i32)); // self
+                    for (i, arg) in arguments.iter().enumerate() {
+                        emit_expr(arg, func, ctx, memory_layout, param_types.get(i + 1));
+                    }
+                    func.instruction(&Instruction::Call(init_idx));
+                    func.instruction(&Instruction::Drop); // discard __init__ return
+                } else {
+                    // No constructor: evaluate and discard any arguments.
+                    for arg in arguments {
+                        let t = emit_expr(arg, func, ctx, memory_layout, None);
+                        func.instruction(&Instruction::Drop);
+                        if matches!(t, IRType::String | IRType::Bytes) {
+                            func.instruction(&Instruction::Drop);
+                        }
+                    }
+                }
+                func.instruction(&Instruction::I32Const(instance_ptr as i32)); // result
+                return IRType::Class(function_name.clone());
+            }
+
             // Push arguments onto the stack in order
             let mut arg_types = Vec::new();
             for arg in arguments {
                 let arg_type = emit_expr(arg, func, ctx, memory_layout, None);
                 arg_types.push(arg_type);
-            }
-
-            // Check if this is a class instantiation
-            if let Some(class_info) = ctx.get_class_info(function_name) {
-                // Allocate space for the object instance
-                // For now, use a fixed allocation strategy - sequential allocation
-                let instance_ptr = 65536
-                    + (ctx
-                        .get_class_info(function_name)
-                        .map(|c| c.instance_size)
-                        .unwrap_or(0));
-                func.instruction(&Instruction::I32Const(instance_ptr as i32));
-
-                // Call __init__ method if it exists
-                if let Some(&init_func_idx) = class_info.methods.get("__init__") {
-                    // Stack: ...object_ptr
-                    // Need to pass self as first argument
-                    // Duplicate object pointer to pass to __init__
-                    func.instruction(&Instruction::LocalSet(ctx.temp_local));
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
-
-                    // Now call __init__ with self and other arguments
-                    func.instruction(&Instruction::Call(init_func_idx));
-                    // Drop the return value from __init__
-                    func.instruction(&Instruction::Drop);
-                }
-
-                return IRType::Class(function_name.clone());
             }
 
             // Look up the function index if it exists in our context
@@ -1643,23 +1666,26 @@ pub fn emit_expr(
                 };
             }
 
+            // `ClassName.var` reads a class-level variable; inline its value.
+            if let IRExpr::Variable(class_name) = &**object {
+                if let Some(class_info) = ctx.get_class_info(class_name) {
+                    if let Some(value) = class_info.class_var_values.get(attribute) {
+                        let value = value.clone();
+                        return emit_expr(&value, func, ctx, memory_layout, expected_type);
+                    }
+                }
+            }
+
             let obj_type = emit_expr(object, func, ctx, memory_layout, None);
 
             match &obj_type {
                 IRType::Class(class_name) => {
-                    if let Some(class_info) = ctx.get_class_info(class_name) {
-                        if let Some(&field_offset) = class_info.field_offsets.get(attribute) {
-                            func.instruction(&Instruction::I32Load(MemArg {
-                                offset: field_offset,
-                                align: 2,
-                                memory_index: 0,
-                            }));
-                            IRType::Unknown
-                        } else {
-                            func.instruction(&Instruction::Drop);
-                            func.instruction(&Instruction::I32Const(0));
-                            IRType::Unknown
-                        }
+                    // Instance field read: load with the field's width and report
+                    // its type so float fields participate in f64 arithmetic.
+                    if let Some((field_offset, field_ty)) = lookup_field(ctx, class_name, attribute)
+                    {
+                        func.instruction(&load_field_instr(&field_ty, field_offset));
+                        field_ty
                     } else {
                         func.instruction(&Instruction::Drop);
                         func.instruction(&Instruction::I32Const(0));
@@ -1667,7 +1693,6 @@ pub fn emit_expr(
                     }
                 }
                 _ => {
-                    emit_expr(object, func, ctx, memory_layout, None);
                     func.instruction(&Instruction::Drop);
                     func.instruction(&Instruction::I32Const(0));
                     IRType::Unknown
@@ -3360,30 +3385,26 @@ pub fn emit_expr(
                     emit_tuple_method_call(func, ctx, memory_layout, method_name, arguments)
                 }
                 IRType::Class(class_name) => {
-                    // Custom class method call
-                    if let Some(class_info) = ctx.get_class_info(class_name) {
-                        if let Some(&method_idx) = class_info.methods.get(method_name.as_str()) {
-                            // Stack has object pointer already on top
-                            // Evaluate and push arguments
-                            for arg in arguments {
-                                emit_expr(arg, func, ctx, memory_layout, None);
-                            }
-                            // Call the method
-                            func.instruction(&Instruction::Call(method_idx));
-                            // For now, assume method returns an unknown type
-                            IRType::Unknown
-                        } else {
-                            // Method not found on class
-                            func.instruction(&Instruction::Drop); // drop object
-                            for arg in arguments {
-                                emit_expr(arg, func, ctx, memory_layout, None);
-                                func.instruction(&Instruction::Drop);
-                            }
-                            IRType::Unknown
+                    // Custom class method call. The object pointer (`self`) is
+                    // already on the stack; coerce the user arguments to the
+                    // method's declared parameter types and report its real
+                    // return type so float results flow correctly.
+                    let method_idx = ctx
+                        .get_class_info(class_name)
+                        .and_then(|ci| ci.methods.get(method_name.as_str()).copied());
+                    if let Some(method_idx) = method_idx {
+                        let (param_types, ret) = ctx
+                            .get_function_info(&format!("{class_name}::{method_name}"))
+                            .map(|f| (f.param_types.clone(), f.return_type.clone()))
+                            .unwrap_or((Vec::new(), IRType::Unknown));
+                        for (i, arg) in arguments.iter().enumerate() {
+                            emit_expr(arg, func, ctx, memory_layout, param_types.get(i + 1));
                         }
+                        func.instruction(&Instruction::Call(method_idx));
+                        ret
                     } else {
-                        // Class not found
-                        func.instruction(&Instruction::Drop); // drop object
+                        // Method or class not found: drop the object and args.
+                        func.instruction(&Instruction::Drop);
                         for arg in arguments {
                             emit_expr(arg, func, ctx, memory_layout, None);
                             func.instruction(&Instruction::Drop);

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -73,6 +73,71 @@ pub fn compile_function(
     func
 }
 
+/// Resolve a class field to its `(byte offset, value type)`, if known.
+pub(crate) fn lookup_field(
+    ctx: &CompilationContext,
+    class_name: &str,
+    field: &str,
+) -> Option<(u64, IRType)> {
+    let class_info = ctx.get_class_info(class_name)?;
+    let offset = *class_info.field_offsets.get(field)?;
+    let ty = class_info
+        .field_types
+        .get(field)
+        .cloned()
+        .unwrap_or(IRType::Unknown);
+    Some((offset, ty))
+}
+
+/// Store instruction for a field of the given type (f64 for floats, i32 else).
+fn store_field_instr(ty: &IRType, offset: u64) -> Instruction<'static> {
+    let mem = MemArg {
+        offset,
+        align: if matches!(ty, IRType::Float) { 3 } else { 2 },
+        memory_index: 0,
+    };
+    if matches!(ty, IRType::Float) {
+        Instruction::F64Store(mem)
+    } else {
+        Instruction::I32Store(mem)
+    }
+}
+
+/// Emit a binary arithmetic op for an augmented field assignment, choosing the
+/// f64 or i32 instruction by operand type.
+fn emit_arith_op(func: &mut Function, op: &IROp, is_float: bool) {
+    let instr = match (op, is_float) {
+        (IROp::Add, false) => Instruction::I32Add,
+        (IROp::Sub, false) => Instruction::I32Sub,
+        (IROp::Mul, false) => Instruction::I32Mul,
+        (IROp::Div, false) | (IROp::FloorDiv, false) => Instruction::I32DivS,
+        (IROp::Mod, false) => Instruction::I32RemS,
+        (IROp::Add, true) => Instruction::F64Add,
+        (IROp::Sub, true) => Instruction::F64Sub,
+        (IROp::Mul, true) => Instruction::F64Mul,
+        (IROp::Div, true) | (IROp::FloorDiv, true) => Instruction::F64Div,
+        // Anything else (e.g. Pow, bitwise) is uncommon for fields; fall back to
+        // a numeric add so the stack stays balanced.
+        (_, true) => Instruction::F64Add,
+        (_, false) => Instruction::I32Add,
+    };
+    func.instruction(&instr);
+}
+
+/// Load instruction for a field of the given type (f64 for floats, i32 else).
+pub(crate) fn load_field_instr(ty: &IRType, offset: u64) -> Instruction<'static> {
+    let mem = MemArg {
+        offset,
+        align: if matches!(ty, IRType::Float) { 3 } else { 2 },
+        memory_index: 0,
+    };
+    if matches!(ty, IRType::Float) {
+        Instruction::F64Load(mem)
+    } else {
+        Instruction::I32Load(mem)
+    }
+}
+
 /// Get the type of a local variable by its index
 fn get_local_type_by_index(ctx: &CompilationContext, index: u32) -> IRType {
     for local_info in ctx.locals_map.values() {
@@ -278,6 +343,7 @@ pub fn compile_body(
                                 | IRType::Set(_)
                                 | IRType::String
                                 | IRType::Bytes
+                                | IRType::Class(_)
                         )
                     {
                         info.var_type = value_type;
@@ -407,10 +473,19 @@ pub fn compile_body(
             IRStatement::Expression(expr) => {
                 // Discard the result only when the expression actually leaves a
                 // value. Calls like print() return None and push nothing, so an
-                // unconditional drop would underflow the stack.
+                // unconditional drop would underflow the stack. String/bytes
+                // values (e.g. a docstring statement) are an (offset, length)
+                // pair and need two drops.
                 let result_type = emit_expr(expr, func, ctx, memory_layout, None);
-                if !matches!(result_type, IRType::None) {
-                    func.instruction(&Instruction::Drop);
+                match result_type {
+                    IRType::None => {}
+                    IRType::String | IRType::Bytes => {
+                        func.instruction(&Instruction::Drop);
+                        func.instruction(&Instruction::Drop);
+                    }
+                    _ => {
+                        func.instruction(&Instruction::Drop);
+                    }
                 }
             }
             IRStatement::AttributeAssign {
@@ -418,42 +493,27 @@ pub fn compile_body(
                 attribute,
                 value,
             } => {
-                // Emit code for the object (get reference)
+                // Emit the object reference (the store address) first; a WASM
+                // store pops the value, then the address.
                 let obj_type = emit_expr(object, func, ctx, memory_layout, None);
 
-                // Store the object reference temporarily
-                func.instruction(&Instruction::LocalSet(ctx.temp_local));
+                let field = match &obj_type {
+                    IRType::Class(class_name) => lookup_field(ctx, class_name, attribute),
+                    _ => None,
+                };
 
-                // Emit code for the value
-                emit_expr(value, func, ctx, memory_layout, None);
-
-                // Store the value temporarily
-                func.instruction(&Instruction::LocalSet(ctx.temp_local + 1));
-
-                // Load the object reference
-                func.instruction(&Instruction::LocalGet(ctx.temp_local));
-
-                // Check if object is a custom class
-                if let crate::ir::IRType::Class(class_name) = &obj_type {
-                    if let Some(class_info) = ctx.get_class_info(class_name) {
-                        if let Some(&field_offset) = class_info.field_offsets.get(attribute) {
-                            // Stack: object_ptr
-                            // Load the value to store
-                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
-                            // Store value at object_ptr + field_offset
-                            func.instruction(&Instruction::I32Store(MemArg {
-                                offset: field_offset,
-                                align: 2,
-                                memory_index: 0,
-                            }));
-                            return;
-                        }
-                    }
+                if let Some((field_offset, field_ty)) = field {
+                    // Stack: object_ptr. Emit the value coerced to the field's
+                    // type, then store with the matching width (f64 for float
+                    // fields, i32 otherwise).
+                    emit_expr(value, func, ctx, memory_layout, Some(&field_ty));
+                    func.instruction(&store_field_instr(&field_ty, field_offset));
+                } else {
+                    // Unknown field: drop the address and the value.
+                    emit_expr(value, func, ctx, memory_layout, None);
+                    func.instruction(&Instruction::Drop);
+                    func.instruction(&Instruction::Drop);
                 }
-
-                // Fallback: drop everything
-                func.instruction(&Instruction::Drop); // Drop object pointer
-                func.instruction(&Instruction::Drop); // Drop value
             }
 
             IRStatement::AugAssign { target, value, op } => {
@@ -507,22 +567,34 @@ pub fn compile_body(
 
             IRStatement::AttributeAugAssign {
                 object,
-                attribute: _, // Ignore the attribute field for now
+                attribute,
                 value,
-                op: _, // Ignore the operation for now
+                op,
             } => {
-                // This is a simplified implementation that doesn't actually perform the operation
-                // It's just a placeholder to get the code to compile
+                // `obj.field OP= value` -> obj.field = (obj.field OP value).
+                let obj_type = emit_expr(object, func, ctx, memory_layout, None);
+                func.instruction(&Instruction::LocalSet(ctx.temp_local)); // temp = obj_ptr
 
-                // Emit code for the object (get reference)
-                emit_expr(object, func, ctx, memory_layout, None);
+                let field = match &obj_type {
+                    IRType::Class(class_name) => lookup_field(ctx, class_name, attribute),
+                    _ => None,
+                };
 
-                // Emit code for the value
-                emit_expr(value, func, ctx, memory_layout, None);
-
-                // For now, just drop the values - we don't have a proper object system
-                func.instruction(&Instruction::Drop);
-                func.instruction(&Instruction::Drop);
+                if let Some((offset, field_ty)) = field {
+                    let is_float = matches!(field_ty, IRType::Float);
+                    // Store address.
+                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                    // Current field value.
+                    func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                    func.instruction(&load_field_instr(&field_ty, offset));
+                    // Operand, coerced to the field's type.
+                    emit_expr(value, func, ctx, memory_layout, Some(&field_ty));
+                    emit_arith_op(func, op, is_float);
+                    func.instruction(&store_field_instr(&field_ty, offset));
+                } else {
+                    emit_expr(value, func, ctx, memory_layout, None);
+                    func.instruction(&Instruction::Drop);
+                }
             }
 
             IRStatement::For {

--- a/src/compiler/module.rs
+++ b/src/compiler/module.rs
@@ -1,6 +1,6 @@
 use crate::compiler::context::{ClassInfo, CompilationContext, COLLECTION_HEAP_BASE};
 use crate::compiler::function::compile_function;
-use crate::ir::{IRModule, IRType};
+use crate::ir::{IRBody, IRConstant, IRExpr, IRModule, IRStatement, IRType};
 use std::collections::HashMap;
 use wasm_encoder::{
     CodeSection, ConstExpr, DataSection, ExportSection, FunctionSection, MemorySection, MemoryType,
@@ -16,6 +16,78 @@ fn ir_type_to_wasm_type(ir_type: &IRType) -> ValType {
         IRType::List(_) | IRType::Dict(_, _) | IRType::Tuple(_) => ValType::I32, // Collections are pointers
         IRType::Optional(_) | IRType::Union(_) => ValType::I32, // References to optionals/unions
         _ => ValType::I32,
+    }
+}
+
+/// Is this expression a reference to the implicit `self` parameter?
+fn is_self_ref(expr: &IRExpr) -> bool {
+    matches!(expr, IRExpr::Variable(n) | IRExpr::Param(n) if n == "self")
+}
+
+/// Best-effort type inference for a class field initializer. Only needs to
+/// distinguish floats (an f64 slot) from the i32-shaped default; `params` maps
+/// the enclosing method's parameter names to their annotated types so that
+/// `self.width = width` adopts `width`'s declared type.
+fn infer_field_value_type(value: &IRExpr, params: &HashMap<String, IRType>) -> IRType {
+    match value {
+        IRExpr::Const(IRConstant::Float(_)) => IRType::Float,
+        IRExpr::Const(IRConstant::Int(_)) => IRType::Int,
+        IRExpr::Const(IRConstant::Bool(_)) => IRType::Bool,
+        IRExpr::Variable(name) | IRExpr::Param(name) => {
+            params.get(name).cloned().unwrap_or(IRType::Unknown)
+        }
+        IRExpr::BinaryOp { left, right, .. } => {
+            let lt = infer_field_value_type(left, params);
+            let rt = infer_field_value_type(right, params);
+            if lt == IRType::Float || rt == IRType::Float {
+                IRType::Float
+            } else {
+                lt
+            }
+        }
+        IRExpr::UnaryOp { operand, .. } => infer_field_value_type(operand, params),
+        _ => IRType::Unknown,
+    }
+}
+
+/// Collect `self.<field> = value` assignments (including augmented ones) from a
+/// method body, recursing into nested blocks, with each field's inferred type.
+fn collect_self_fields(
+    body: &IRBody,
+    params: &HashMap<String, IRType>,
+    out: &mut Vec<(String, IRType)>,
+) {
+    for stmt in &body.statements {
+        match stmt {
+            IRStatement::AttributeAssign {
+                object,
+                attribute,
+                value,
+            } if is_self_ref(object) => {
+                out.push((attribute.clone(), infer_field_value_type(value, params)));
+            }
+            IRStatement::AttributeAugAssign {
+                object,
+                attribute,
+                value,
+                ..
+            } if is_self_ref(object) => {
+                out.push((attribute.clone(), infer_field_value_type(value, params)));
+            }
+            IRStatement::If {
+                then_body,
+                else_body,
+                ..
+            } => {
+                collect_self_fields(then_body, params, out);
+                if let Some(else_body) = else_body {
+                    collect_self_fields(else_body, params, out);
+                }
+            }
+            IRStatement::While { body, .. } => collect_self_fields(body, params, out),
+            IRStatement::For { body, .. } => collect_self_fields(body, params, out),
+            _ => {}
+        }
     }
 }
 
@@ -101,17 +173,56 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
             name: cls.name.clone(),
             methods: HashMap::new(),
             field_offsets: HashMap::new(),
+            field_types: HashMap::new(),
+            class_var_values: HashMap::new(),
             instance_size: 0,
         };
 
-        // Calculate field offsets and instance size
-        let mut current_offset = 4u64; // 4 bytes for type tag at offset 0
+        // Each field is an 8-byte slot (holds an i32 or an f64); the first 4
+        // bytes are reserved for a type tag. `add_field` assigns the next slot
+        // the first time a field name is seen and records its value type.
+        let mut current_offset = 4u64;
+        let add_field = |info: &mut ClassInfo, name: &str, ty: IRType, current_offset: &mut u64| {
+            if !info.field_offsets.contains_key(name) {
+                info.field_offsets.insert(name.to_string(), *current_offset);
+                *current_offset += 8;
+            }
+            // Prefer a concrete type over an earlier `Unknown` inference.
+            let entry = info
+                .field_types
+                .entry(name.to_string())
+                .or_insert(IRType::Unknown);
+            if matches!(entry, IRType::Unknown) {
+                *entry = ty;
+            }
+        };
+
+        // Class-level variables occupy instance slots and are also accessible as
+        // `ClassName.var`; keep their initializers for that read path.
         for var in &cls.class_vars {
+            let ty = var
+                .var_type
+                .clone()
+                .unwrap_or_else(|| infer_field_value_type(&var.value, &HashMap::new()));
+            add_field(&mut class_info, &var.name, ty, &mut current_offset);
             class_info
-                .field_offsets
-                .insert(var.name.clone(), current_offset);
-            // Each field is 8 bytes (can hold i32 or f64)
-            current_offset += 8;
+                .class_var_values
+                .insert(var.name.clone(), var.value.clone());
+        }
+
+        // Instance fields are discovered from `self.<field> = ...` assignments in
+        // method bodies (their types inferred from the method's parameters).
+        for method in &cls.methods {
+            let params: HashMap<String, IRType> = method
+                .params
+                .iter()
+                .map(|p| (p.name.clone(), p.param_type.clone()))
+                .collect();
+            let mut fields = Vec::new();
+            collect_self_fields(&method.body, &params, &mut fields);
+            for (name, ty) in fields {
+                add_field(&mut class_info, &name, ty, &mut current_offset);
+            }
         }
         class_info.instance_size = current_offset as u32;
 

--- a/src/ir/converter.rs
+++ b/src/ir/converter.rs
@@ -319,7 +319,15 @@ fn process_class_definition(stmt: &Stmt, memory_layout: &mut MemoryLayout) -> Re
                 Stmt::FunctionDef(method_def) => {
                     // Process method (similar to function but with 'self' parameter)
                     let method_name = method_def.name.to_string();
-                    let params = process_function_params(&method_def.args)?;
+                    let mut params = process_function_params(&method_def.args)?;
+                    // The implicit `self` parameter is untyped in source; type it
+                    // as the enclosing class so attribute access/assignment can
+                    // resolve field offsets and types.
+                    if let Some(first) = params.first_mut() {
+                        if first.name == "self" {
+                            first.param_type = IRType::Class(name.clone());
+                        }
+                    }
                     let return_type = if let Some(returns) = &method_def.returns {
                         type_annotation_to_ir_type(returns)?
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -739,6 +739,54 @@ mod collection_tests {
             .expect("call")
     }
 
+    /// A rectangle class with float fields, used by the class+float tests. Each
+    /// test function returns 1 when the float computation matches its expected
+    /// value (the wasmi build in use can't return an f64 directly).
+    const RECT_SRC: &str = "class Rectangle:\n    default_width = 10\n    default_height = 5\n    def __init__(self, width: float, height: float):\n        self.width = width\n        self.height = height\n    def area(self) -> float:\n        return self.width * self.height\n    def perimeter(self) -> float:\n        return 2 * (self.width + self.height)\n    def scale(self, factor: float) -> None:\n        self.width *= factor\n        self.height *= factor\n";
+
+    #[test]
+    fn class_float_fields_and_methods() {
+        // Float instance fields are stored/loaded as f64, and a method returning
+        // a float computes correctly (previously fields read as i32 and the f64
+        // return mismatched).
+        let area = format!(
+            "{RECT_SRC}def f() -> int:\n    r = Rectangle(10.0, 5.0)\n    if r.area() == 50.0:\n        return 1\n    return 0\n"
+        );
+        assert_eq!(call_i32(&area, "f"), 1);
+        // `2 * (a + b)` keeps the float result instead of truncating it to int.
+        let perim = format!(
+            "{RECT_SRC}def f() -> int:\n    r = Rectangle(10.0, 5.0)\n    if r.perimeter() == 30.0:\n        return 1\n    return 0\n"
+        );
+        assert_eq!(call_i32(&perim, "f"), 1);
+    }
+
+    #[test]
+    fn class_int_args_coerced_to_float() {
+        // Int literals passed to float constructor parameters widen to f64.
+        let src = format!(
+            "{RECT_SRC}def f() -> int:\n    r = Rectangle(3, 4)\n    if r.area() == 12.0:\n        return 1\n    return 0\n"
+        );
+        assert_eq!(call_i32(&src, "f"), 1);
+    }
+
+    #[test]
+    fn class_augmented_field_assign() {
+        // `self.width *= factor` performs an f64 load/mul/store (was a no-op).
+        let src = format!(
+            "{RECT_SRC}def f() -> int:\n    r = Rectangle(2.0, 3.0)\n    r.scale(2.0)\n    if r.area() == 24.0:\n        return 1\n    return 0\n"
+        );
+        assert_eq!(call_i32(&src, "f"), 1);
+    }
+
+    #[test]
+    fn class_variable_access() {
+        // `ClassName.classvar` reads the class-level variable's value (10 * 5).
+        let src = format!(
+            "{RECT_SRC}def f() -> int:\n    r = Rectangle(Rectangle.default_width, Rectangle.default_height)\n    if r.area() == 50.0:\n        return 1\n    return 0\n"
+        );
+        assert_eq!(call_i32(&src, "f"), 1);
+    }
+
     #[test]
     fn float_list_roundtrips() {
         // Reads the float element back and compares (returns 1 on match). The


### PR DESCRIPTION
`module_level_demo.py` failed to validate: a class with float fields (`width: float`) read those fields as i32, so `self.width * self.height` and float-returning methods produced i32/f64 type mismatches, and `Rectangle(10, 5)` passed ints to float parameters.

Classes now carry per-field types. Instance fields are discovered from `self.<field> = ...` assignments in method bodies and typed from the enclosing method's parameters (or the literal value), alongside the existing class-level vars. Field reads and writes use the matching width (f64 for float fields, i32 otherwise), and `self` is typed as its class so attribute access resolves at all.

Argument coercion now happens at call sites: the instance pointer is passed as `self` (first argument, previously mis-ordered), and constructor/method arguments are emitted against their declared parameter types, so int literals widen to f64. Augmented field assignment (`self.x *= f`, previously a no-op) and class-variable reads (`ClassName.var`) are implemented, and method calls report the method's real return type.

Two general bugs surfaced and are fixed alongside:

- An expression-statement of string/bytes type (e.g. a docstring) left its `(offset, length)` pair on the stack instead of dropping both, overflowing the result of `__init__`/`scale`.
- A binary op forced its right operand to the left operand's type, so `2 * (a_float + b_float)` truncated the float subexpression to int. The right operand is now emitted at its natural type and the existing int/float widening promotes whichever side is the integer.

Adds tests for float fields, int->float constructor args, augmented field assignment, and class-variable access.

Fixes #82