### PR TITLE
fix(codegen): infer float return types and stdlib float locals

### DIFF
--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -8,6 +8,7 @@ pub fn compile_function(
     ir_func: &IRFunction,
     ctx: &mut CompilationContext,
     memory_layout: &MemoryLayout,
+    return_type: &IRType,
 ) -> Function {
     ctx.locals_map.clear();
     ctx.local_count = 0;
@@ -55,13 +56,12 @@ pub fn compile_function(
     // Compile the function body
     compile_body(&ir_func.body, &mut func, ctx, memory_layout);
 
-    // Add default return value if no explicit return
-    match ir_func.return_type {
+    // Add default return value if no explicit return. Use the resolved return
+    // type (which may have been inferred from the body) so the fall-through
+    // value matches the function's declared WASM result.
+    match return_type {
         IRType::Float => {
             func.instruction(&Instruction::F64Const(0.0_f64.into()));
-        }
-        IRType::None => {
-            func.instruction(&Instruction::I32Const(0));
         }
         _ => {
             func.instruction(&Instruction::I32Const(0));
@@ -110,6 +110,19 @@ fn infer_value_type(value: &IRExpr, ctx: &CompilationContext) -> IRType {
             }
         }
         IRExpr::UnaryOp { operand, .. } => infer_value_type(operand, ctx),
+        // Float-valued stdlib constants (e.g. `math.pi`, `math.e`) must make
+        // their local an f64; otherwise the f64 store lands in an i32 slot.
+        IRExpr::Attribute { object, attribute } => match object.as_ref() {
+            IRExpr::Variable(module)
+                if matches!(
+                    crate::stdlib::get_stdlib_attributes(module, attribute),
+                    Some(crate::stdlib::StdlibValue::Float(_))
+                ) =>
+            {
+                IRType::Float
+            }
+            _ => IRType::Unknown,
+        },
         IRExpr::Variable(name) => ctx
             .get_local_info(name)
             .map(|info| info.var_type.clone())
@@ -121,6 +134,70 @@ fn infer_value_type(value: &IRExpr, ctx: &CompilationContext) -> IRType {
             .filter(|t| *t == IRType::Float)
             .unwrap_or(IRType::Unknown),
         _ => IRType::Unknown,
+    }
+}
+
+/// Resolve a function's WASM result type. An explicit annotation wins; otherwise
+/// the type is inferred from the body's `return` statements so that, e.g., a
+/// function returning `math.pi` gets an f64 result instead of a default i32 (an
+/// f64 return value into an i32 result fails validation and aborts Binaryen).
+///
+/// `known_returns` carries the already-resolved return types of other functions
+/// so a `return some_call()` resolves; callees defined earlier are resolved
+/// first, and a second resolution pass handles forward references.
+pub(crate) fn resolve_return_type(
+    ir_func: &IRFunction,
+    known_returns: &std::collections::HashMap<String, IRType>,
+) -> IRType {
+    if !matches!(ir_func.return_type, IRType::Unknown) {
+        return ir_func.return_type.clone();
+    }
+
+    // Build a scratch context with the params and known function return types,
+    // then run the local scan so local types (including float stdlib constants)
+    // are available to the return-expression inference.
+    let mut ctx = CompilationContext::new();
+    for (name, ret) in known_returns {
+        ctx.add_function(name, 0, Vec::new(), ret.clone());
+    }
+    for param in &ir_func.params {
+        ctx.add_local(&param.name, param.param_type.clone());
+    }
+    ctx.for_loop_seq = 0;
+    scan_and_allocate_locals(&ir_func.body, &mut ctx);
+
+    let mut inferred = IRType::Unknown;
+    collect_return_type(&ir_func.body, &ctx, &mut inferred);
+    inferred
+}
+
+/// Fold the inferred types of a body's `return` expressions into `out`. A float
+/// return forces an f64 result; otherwise the first concrete type seen wins.
+fn collect_return_type(body: &IRBody, ctx: &CompilationContext, out: &mut IRType) {
+    for stmt in &body.statements {
+        match stmt {
+            IRStatement::Return(Some(expr)) => {
+                let t = infer_value_type(expr, ctx);
+                if t == IRType::Float {
+                    *out = IRType::Float;
+                } else if matches!(out, IRType::Unknown) && !matches!(t, IRType::Unknown) {
+                    *out = t;
+                }
+            }
+            IRStatement::If {
+                then_body,
+                else_body,
+                ..
+            } => {
+                collect_return_type(then_body, ctx, out);
+                if let Some(else_body) = else_body {
+                    collect_return_type(else_body, ctx, out);
+                }
+            }
+            IRStatement::While { body, .. } => collect_return_type(body, ctx, out),
+            IRStatement::For { body, .. } => collect_return_type(body, ctx, out),
+            _ => {}
+        }
     }
 }
 

--- a/src/compiler/module.rs
+++ b/src/compiler/module.rs
@@ -1,5 +1,5 @@
 use crate::compiler::context::{ClassInfo, CompilationContext, COLLECTION_HEAP_BASE};
-use crate::compiler::function::compile_function;
+use crate::compiler::function::{compile_function, resolve_return_type};
 use crate::ir::{IRModule, IRType};
 use std::collections::HashMap;
 use wasm_encoder::{
@@ -32,6 +32,37 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         ctx.add_module_var(&var.name, var.var_type.clone(), var.value.clone());
     }
 
+    // Resolve each function's (and method's) return type up front, inferring
+    // unannotated ones from their bodies, so the type section, the registered
+    // signatures, and the emitted code all use the same result type. Two passes
+    // let a function's inferred return type depend on a callee resolved later in
+    // the first pass.
+    let mut resolved_returns: HashMap<String, IRType> = HashMap::new();
+    for _ in 0..2 {
+        for func in &ir_module.functions {
+            let rt = resolve_return_type(func, &resolved_returns);
+            resolved_returns.insert(func.name.clone(), rt);
+        }
+        for cls in &ir_module.classes {
+            for method in &cls.methods {
+                let rt = resolve_return_type(method, &resolved_returns);
+                resolved_returns.insert(format!("{}::{}", cls.name, method.name), rt);
+            }
+        }
+    }
+    let module_return = |func: &crate::ir::IRFunction| -> IRType {
+        resolved_returns
+            .get(&func.name)
+            .cloned()
+            .unwrap_or_else(|| func.return_type.clone())
+    };
+    let method_return = |class: &str, method: &crate::ir::IRFunction| -> IRType {
+        resolved_returns
+            .get(&format!("{class}::{}", method.name))
+            .cloned()
+            .unwrap_or_else(|| method.return_type.clone())
+    };
+
     // Build type section
     let mut types = TypeSection::new();
 
@@ -51,7 +82,7 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
             .collect();
 
         // Map IR return type to WebAssembly type
-        let results = vec![ir_type_to_wasm_type(&func.return_type)];
+        let results = vec![ir_type_to_wasm_type(&module_return(func))];
 
         // Add the type to the type section
         types.ty().function(params, results);
@@ -65,7 +96,7 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
                 .iter()
                 .map(|param| ir_type_to_wasm_type(&param.param_type))
                 .collect();
-            let results = vec![ir_type_to_wasm_type(&method.return_type)];
+            let results = vec![ir_type_to_wasm_type(&method_return(&cls.name, method))];
             types.ty().function(params, results);
         }
     }
@@ -88,7 +119,7 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         // Register function in context
         let param_types = func.params.iter().map(|p| p.param_type.clone()).collect();
 
-        ctx.add_function(&func.name, func_idx, param_types, func.return_type.clone());
+        ctx.add_function(&func.name, func_idx, param_types, module_return(func));
 
         // Export the function
         exports.export(&func.name, wasm_encoder::ExportKind::Func, func_idx);
@@ -124,7 +155,7 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
                 &qualified_name,
                 func_idx,
                 param_types,
-                method.return_type.clone(),
+                method_return(&cls.name, method),
             );
 
             class_info.methods.insert(method.name.clone(), func_idx);
@@ -171,14 +202,16 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     let mut codes = CodeSection::new();
 
     for func_ir in &ir_module.functions {
-        let compiled_func = compile_function(func_ir, &mut ctx, &memory_layout);
+        let return_type = module_return(func_ir);
+        let compiled_func = compile_function(func_ir, &mut ctx, &memory_layout, &return_type);
         codes.function(&compiled_func);
     }
 
     // Compile class methods
     for cls in &ir_module.classes {
         for method in &cls.methods {
-            let compiled_method = compile_function(method, &mut ctx, &memory_layout);
+            let return_type = method_return(&cls.name, method);
+            let compiled_method = compile_function(method, &mut ctx, &memory_layout, &return_type);
             codes.function(&compiled_method);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,6 +860,24 @@ mod collection_tests {
     }
 
     #[test]
+    fn math_float_constant_local() {
+        // `math.pi`/`math.tau` are f64 stdlib constants; their locals must be
+        // f64 (previously an f64 store landed in an i32 slot, which failed
+        // validation and aborted Binaryen during optimization).
+        let src = "import math\ndef f() -> int:\n    pi = math.pi\n    tau = math.tau\n    if tau > pi:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
+    }
+
+    #[test]
+    fn unannotated_function_returning_float() {
+        // An unannotated function that returns a float gets an f64 result type
+        // inferred from its body, so a caller sees an f64 (previously the i32
+        // result signature mismatched the f64 return value).
+        let src = "import math\ndef get_pi():\n    pi = math.pi\n    return pi\ndef f() -> int:\n    if get_pi() > 3.0:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
+    }
+
+    #[test]
     fn min_and_max_reduce() {
         // The reduction previously left the if/else stack unbalanced.
         let src = "def lo() -> int:\n    return min(5, 3, 8, 1, 9)\ndef hi() -> int:\n    return max(5, 3, 8, 1, 9)\n";


### PR DESCRIPTION
`test_math.py` and `stdlib_all_modules.py` aborted the compiler during optimization (an uncatchable Binaryen `UNREACHABLE` assertion). The raw module was invalid: an f64 value was being written into an i32 slot, which Binaryen reads but chokes on while optimizing.

Two paths produced that mismatch, both now fixed:

- A local bound to a float stdlib constant (`pi = math.pi`) was typed as the i32-shaped default, so the f64 store failed validation. The local type inference now recognises float-valued stdlib attributes and types the local f64.
- An unannotated function that returns a float had a default i32 result, so the f64 return value mismatched the signature. Function (and method) return types are now resolved up front — an explicit annotation wins, otherwise the type is inferred from the body's `return` statements — and that resolved type drives the type section, the registered signature, the fall-through return value, and callers' inference consistently. Two resolution passes let a function's inferred type depend on a callee.

Adds tests for a float stdlib-constant local and for an unannotated function whose float return type is inferred and consumed by a caller.

Fixes #83