### PR TITLE
feat(codegen): support break and continue in loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `break` and `continue` statements in `for` and `while` loops. Each loop body is wrapped in an inner block so `continue` falls through to the iterator step, and a block-depth counter plus loop-context stack compute the correct branch depth so break/continue nested inside `if`/`try` frames or nested loops target the right loop ([#23](https://github.com/anistark/waspy/issues/23))
+
+### Fixed
+- `for x in <list>` read each element from `ptr + i*4` with load offset 0, loading the leading length word as element 0 and dropping the last element; the load now uses a `+4` offset so iteration sees the real elements
+
 ## [0.10.0](https://github.com/anistark/waspy/releases/tag/v0.10.0) - 2026-06-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Generate & Optimize
 - Compiles Python functions to WebAssembly
 - Supports multiple functions in a single WebAssembly module
 - Compiles multiple files into a single module
-- Handles control flow with if/else and while loops
+- Handles control flow with if/else, while and for loops, including `break` and `continue`
 - Processes variable declarations and assignments
 - Supports type annotations for function parameters and return values
 - Enables function calls between compiled functions
@@ -222,7 +222,9 @@ The type system now includes:
 The compiler supports basic control flow constructs:
 
 - **If/Else Statements**: Conditional execution using WebAssembly's block and branch instructions
-- **While Loops**: Implemented using WebAssembly's loop and branch instructions
+- **While and For Loops**: Implemented using WebAssembly's loop and branch instructions
+- **Break and Continue**: Early loop exit and next-iteration skip, including correct
+  behavior when nested inside `if`/`try` blocks and in nested loops
 - **Comparison Operators**: All standard Python comparison operators
 - **Boolean Operators**: Support for `and` and `or` with short-circuit evaluation
 

--- a/docs/modules.html
+++ b/docs/modules.html
@@ -95,6 +95,7 @@
                     { name: "if/elif/else statements", status: "done", version: "0.1.0" },
                     { name: "while loops", status: "done", version: "0.1.0" },
                     { name: "for loops with list/string iteration", status: "done", version: "0.7.0" },
+                    { name: "break and continue in loops", status: "done", version: "0.11.0" },
                     { name: "try/except/finally exception handling", status: "done", version: "0.7.0" },
                     { name: "with statements and context managers", status: "done", version: "0.7.0" },
                     { name: "Comparison operations (==, !=, <, <=, >, >=)", status: "done", version: "0.1.0" },
@@ -221,6 +222,7 @@
                 version: "0.7.0",
                 features: [
                     { name: "for loops with list/string iteration", status: "done", version: "0.7.0" },
+                    { name: "break and continue (with correct nesting in if/try/loops)", status: "done", version: "0.11.0" },
                     { name: "try/except/finally with exception handling", status: "done", version: "0.7.0" },
                     { name: "with statements and context managers", status: "done", version: "0.7.0" },
                     { name: "Exception type matching and handlers", status: "done", version: "0.7.0" }

--- a/examples/loop_control.py
+++ b/examples/loop_control.py
@@ -1,0 +1,51 @@
+def sum_until_five() -> int:
+    # `break` exits the loop early.
+    total = 0
+    for i in range(100):
+        if i == 5:
+            break
+        total = total + i
+    return total
+
+
+def sum_odds_below_ten() -> int:
+    # `continue` skips to the next iteration.
+    total = 0
+    for i in range(10):
+        if i % 2 == 0:
+            continue
+        total = total + i
+    return total
+
+
+def first_multiple_over(limit: int, step: int) -> int:
+    # `break`/`continue` inside a `while` loop.
+    value = 0
+    while True:
+        value = value + step
+        if value <= limit:
+            continue
+        break
+    return value
+
+
+def count_inner_breaks() -> int:
+    # `break` only exits the innermost loop.
+    count = 0
+    for i in range(3):
+        for j in range(3):
+            if j == 1:
+                break
+            count = count + 1
+    return count
+
+
+def main():
+    print(sum_until_five())
+    print(sum_odds_below_ten())
+    print(first_multiple_over(10, 3))
+    print(count_inner_breaks())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -28,6 +28,19 @@ pub struct LocalInfo {
     pub var_type: IRType,
 }
 
+/// Branch targets for an enclosing loop, used to lower `break`/`continue`.
+///
+/// Each field records the value of [`CompilationContext::block_depth`] captured
+/// immediately after the target frame was opened. A branch emitted at the
+/// current depth `c` reaches that frame with `Br(c - level)`, so `break` targets
+/// the loop's outer block and `continue` targets an inner block wrapped around
+/// the loop body (whose end falls through to the iterator step).
+#[derive(Clone, Copy)]
+pub struct LoopContext {
+    pub break_level: u32,
+    pub continue_level: u32,
+}
+
 /// Function
 pub struct FunctionInfo {
     pub index: u32,
@@ -62,6 +75,16 @@ pub struct CompilationContext {
     /// local-allocation scan and by codegen so each loop reuses the iterator
     /// helper locals (`__iter_*_{n}`) reserved for it. Reset per function.
     pub for_loop_seq: u32,
+    /// Number of WASM structured-control frames (`block`/`loop`/`if`) currently
+    /// open at the codegen point. Bumped around the body of each construct that
+    /// can wrap a `break`/`continue` and unwound on the matching `end`. Combined
+    /// with `loop_stack` it yields the relative branch depth for loop control.
+    /// Reset per function.
+    pub block_depth: u32,
+    /// Stack of enclosing loops (innermost last). Empty outside any loop; a
+    /// `break`/`continue` with an empty stack is a compile error (Python would
+    /// raise `SyntaxError`). Reset per function.
+    pub loop_stack: Vec<LoopContext>,
     /// Running high-water mark of the collection heap, in bytes past
     /// `COLLECTION_HEAP_BASE`. Each literal reserves a fresh region here, so it
     /// grows monotonically across the whole module. A `Cell` because codegen
@@ -83,6 +106,8 @@ impl CompilationContext {
             temp_local: 0,
             temp_local_f64: 0,
             for_loop_seq: 0,
+            block_depth: 0,
+            loop_stack: Vec::new(),
             collection_alloc_offset: Cell::new(0),
         }
     }

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -1,4 +1,6 @@
-use crate::compiler::context::{strlen_local_name, CompilationContext, SCRATCH_LOCALS};
+use crate::compiler::context::{
+    strlen_local_name, CompilationContext, LoopContext, SCRATCH_LOCALS,
+};
 use crate::compiler::expression::{emit_expr, emit_integer_power_operation};
 use crate::ir::{IRBody, IRConstant, IRExpr, IRFunction, IROp, IRStatement, IRType, MemoryLayout};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
@@ -52,6 +54,10 @@ pub fn compile_function(
     // Replay the same for-loop numbering used by the scan above so codegen
     // resolves the matching iterator helper locals.
     ctx.for_loop_seq = 0;
+
+    // Loop-control bookkeeping starts empty for each function.
+    ctx.block_depth = 0;
+    ctx.loop_stack.clear();
 
     // Compile the function body
     compile_body(&ir_func.body, &mut func, ctx, memory_layout);
@@ -530,6 +536,10 @@ pub fn compile_body(
                 // If-else block with no result value
                 func.instruction(&Instruction::If(BlockType::Empty));
 
+                // The `if`/`else` frame wraps both branches, so a break/continue
+                // nested here is one level deeper than the surrounding loop body.
+                ctx.block_depth += 1;
+
                 // branch
                 compile_body(then_body, func, ctx, memory_layout);
 
@@ -539,6 +549,7 @@ pub fn compile_body(
                     compile_body(else_body, func, ctx, memory_layout);
                 }
 
+                ctx.block_depth -= 1;
                 func.instruction(&Instruction::End);
             }
 
@@ -569,23 +580,45 @@ pub fn compile_body(
             }
 
             IRStatement::While { condition, body } => {
-                // Loop block
+                // Outer block: `break` branches here to exit the loop.
                 func.instruction(&Instruction::Block(BlockType::Empty));
+                ctx.block_depth += 1;
+                let break_level = ctx.block_depth;
+
                 func.instruction(&Instruction::Loop(BlockType::Empty));
+                ctx.block_depth += 1;
 
                 // Condition check: exit the loop when the condition is false.
+                // Emitted before the inner continue block so this `BrIf(1)` still
+                // targets the outer break block from inside the loop.
                 emit_expr(condition, func, ctx, memory_layout, Some(&IRType::Bool));
                 func.instruction(&Instruction::I32Eqz);
                 func.instruction(&Instruction::BrIf(1));
 
+                // Inner block: `continue` branches to its end, which falls through
+                // to the back-edge below and re-evaluates the loop condition.
+                func.instruction(&Instruction::Block(BlockType::Empty));
+                ctx.block_depth += 1;
+                let continue_level = ctx.block_depth;
+
                 // Loop body
+                ctx.loop_stack.push(LoopContext {
+                    break_level,
+                    continue_level,
+                });
                 compile_body(body, func, ctx, memory_layout);
+                ctx.loop_stack.pop();
+
+                ctx.block_depth -= 1;
+                func.instruction(&Instruction::End); // end continue block
 
                 // Jump back to the start of the loop
                 func.instruction(&Instruction::Br(0));
 
-                // End of loop and block
+                // End of loop and outer break block
+                ctx.block_depth -= 1;
                 func.instruction(&Instruction::End);
+                ctx.block_depth -= 1;
                 func.instruction(&Instruction::End);
             }
             IRStatement::Expression(expr) => {
@@ -765,9 +798,12 @@ pub fn compile_body(
                         func.instruction(&Instruction::I32Const(0));
                         func.instruction(&Instruction::LocalSet(loop_counter_idx));
 
-                        // Loop structure
+                        // Loop structure. Outer block is the `break` target.
                         func.instruction(&Instruction::Block(BlockType::Empty));
+                        ctx.block_depth += 1;
+                        let break_level = ctx.block_depth;
                         func.instruction(&Instruction::Loop(BlockType::Empty));
+                        ctx.block_depth += 1;
 
                         // Check if counter >= length
                         func.instruction(&Instruction::LocalGet(loop_counter_idx));
@@ -777,14 +813,16 @@ pub fn compile_body(
 
                         // Load element from list[counter]
                         // Memory: [length:i32][elem0:i32][elem1:i32]...
-                        // Element at index i is at offset 4 + (i * 4)
+                        // Element at index i is at byte offset 4 + (i * 4): the
+                        // base address is ptr + counter*4 and the load skips the
+                        // leading length word with a +4 element offset.
                         func.instruction(&Instruction::LocalGet(iterator_ptr_idx));
                         func.instruction(&Instruction::LocalGet(loop_counter_idx));
                         func.instruction(&Instruction::I32Const(4));
                         func.instruction(&Instruction::I32Mul);
                         func.instruction(&Instruction::I32Add);
                         func.instruction(&Instruction::I32Load(MemArg {
-                            offset: 0,
+                            offset: 4,
                             align: 2,
                             memory_index: 0,
                         }));
@@ -792,8 +830,21 @@ pub fn compile_body(
                         // Store element in target variable
                         func.instruction(&Instruction::LocalSet(target_idx));
 
+                        // Inner block: `continue` lands at its end, which falls
+                        // through to the counter increment below.
+                        func.instruction(&Instruction::Block(BlockType::Empty));
+                        ctx.block_depth += 1;
+                        let continue_level = ctx.block_depth;
+
                         // Execute the loop body
+                        ctx.loop_stack.push(LoopContext {
+                            break_level,
+                            continue_level,
+                        });
                         compile_body(body, func, ctx, memory_layout);
+                        ctx.loop_stack.pop();
+                        ctx.block_depth -= 1;
+                        func.instruction(&Instruction::End); // end continue block
 
                         // Increment counter
                         func.instruction(&Instruction::LocalGet(loop_counter_idx));
@@ -804,8 +855,10 @@ pub fn compile_body(
                         // Loop back
                         func.instruction(&Instruction::Br(0));
 
-                        // End of loop
+                        // End of loop and break block
+                        ctx.block_depth -= 1;
                         func.instruction(&Instruction::End);
+                        ctx.block_depth -= 1;
                         func.instruction(&Instruction::End);
                     }
                     IRType::Range => {
@@ -825,9 +878,12 @@ pub fn compile_body(
                         func.instruction(&Instruction::I32Const(0));
                         func.instruction(&Instruction::LocalSet(loop_counter_idx));
 
-                        // Loop structure
+                        // Loop structure. Outer block is the `break` target.
                         func.instruction(&Instruction::Block(BlockType::Empty));
+                        ctx.block_depth += 1;
+                        let break_level = ctx.block_depth;
                         func.instruction(&Instruction::Loop(BlockType::Empty));
+                        ctx.block_depth += 1;
 
                         // Load stop and step for comparison
                         func.instruction(&Instruction::LocalGet(iterator_ptr_idx));
@@ -863,8 +919,21 @@ pub fn compile_body(
                         func.instruction(&Instruction::End);
                         func.instruction(&Instruction::BrIf(1)); // Break if true
 
+                        // Inner block: `continue` lands at its end, which falls
+                        // through to the step increment below.
+                        func.instruction(&Instruction::Block(BlockType::Empty));
+                        ctx.block_depth += 1;
+                        let continue_level = ctx.block_depth;
+
                         // Execute the loop body
+                        ctx.loop_stack.push(LoopContext {
+                            break_level,
+                            continue_level,
+                        });
                         compile_body(body, func, ctx, memory_layout);
+                        ctx.loop_stack.pop();
+                        ctx.block_depth -= 1;
+                        func.instruction(&Instruction::End); // end continue block
 
                         // Increment by step
                         func.instruction(&Instruction::LocalGet(target_idx));
@@ -880,8 +949,10 @@ pub fn compile_body(
                         // Loop back
                         func.instruction(&Instruction::Br(0));
 
-                        // End of loop
+                        // End of loop and break block
+                        ctx.block_depth -= 1;
                         func.instruction(&Instruction::End);
+                        ctx.block_depth -= 1;
                         func.instruction(&Instruction::End);
                     }
                     _ => {
@@ -889,17 +960,34 @@ pub fn compile_body(
                         // Treat the value as a count (integer)
                         func.instruction(&Instruction::LocalSet(target_idx));
 
-                        // Simple loop: counter from 1 to value
+                        // Simple loop: counter from 1 to value. Outer block is
+                        // the `break` target.
                         func.instruction(&Instruction::Block(BlockType::Empty));
+                        ctx.block_depth += 1;
+                        let break_level = ctx.block_depth;
                         func.instruction(&Instruction::Loop(BlockType::Empty));
+                        ctx.block_depth += 1;
 
                         func.instruction(&Instruction::LocalGet(target_idx));
                         func.instruction(&Instruction::I32Const(0));
                         func.instruction(&Instruction::I32LeS);
                         func.instruction(&Instruction::BrIf(1));
 
+                        // Inner block: `continue` lands at its end, which falls
+                        // through to the decrement below.
+                        func.instruction(&Instruction::Block(BlockType::Empty));
+                        ctx.block_depth += 1;
+                        let continue_level = ctx.block_depth;
+
                         // Execute body
+                        ctx.loop_stack.push(LoopContext {
+                            break_level,
+                            continue_level,
+                        });
                         compile_body(body, func, ctx, memory_layout);
+                        ctx.loop_stack.pop();
+                        ctx.block_depth -= 1;
+                        func.instruction(&Instruction::End); // end continue block
 
                         // Decrement
                         func.instruction(&Instruction::LocalGet(target_idx));
@@ -908,7 +996,10 @@ pub fn compile_body(
                         func.instruction(&Instruction::LocalSet(target_idx));
 
                         func.instruction(&Instruction::Br(0));
+                        // End of loop and break block
+                        ctx.block_depth -= 1;
                         func.instruction(&Instruction::End);
+                        ctx.block_depth -= 1;
                         func.instruction(&Instruction::End);
                     }
                 }
@@ -943,6 +1034,9 @@ pub fn compile_body(
 
                 // If no exception (flag == 0), skip all except handlers and go to finally
                 func.instruction(&Instruction::If(BlockType::Empty));
+                // The dispatch if/else frame wraps every handler body, so a
+                // break/continue inside a handler is one level deeper.
+                ctx.block_depth += 1;
 
                 // If an exception occurred, check handlers
                 func.instruction(&Instruction::Else);
@@ -985,6 +1079,8 @@ pub fn compile_body(
                         };
 
                         func.instruction(&Instruction::Block(BlockType::Empty));
+                        // This per-handler block wraps the handler body.
+                        ctx.block_depth += 1;
 
                         // Check if exception type matches
                         func.instruction(&Instruction::LocalGet(exception_type_idx));
@@ -1008,6 +1104,7 @@ pub fn compile_body(
                         func.instruction(&Instruction::I32Const(0));
                         func.instruction(&Instruction::LocalSet(exception_flag_idx));
 
+                        ctx.block_depth -= 1;
                         func.instruction(&Instruction::End);
                     }
 
@@ -1022,6 +1119,7 @@ pub fn compile_body(
                 // Close the exception-dispatch if/else. Each typed handler opens
                 // and closes its own block, so only this `If` remains open here;
                 // a second `End` would close the function frame early.
+                ctx.block_depth -= 1;
                 func.instruction(&Instruction::End);
 
                 // If there's a finally block, always execute it
@@ -1322,6 +1420,25 @@ pub fn compile_body(
                 // Full implementation would load and execute the module
                 func.instruction(&Instruction::I32Const(0));
                 func.instruction(&Instruction::LocalSet(_local_idx));
+            }
+
+            IRStatement::Break => {
+                // Branch out of the innermost loop's outer block. The relative
+                // depth accounts for any `if`/`try` frames between here and the
+                // loop. A `break` outside any loop is invalid Python; the parser
+                // rejects it, so emit nothing rather than a malformed branch.
+                if let Some(loop_ctx) = ctx.loop_stack.last().copied() {
+                    func.instruction(&Instruction::Br(ctx.block_depth - loop_ctx.break_level));
+                }
+            }
+
+            IRStatement::Continue => {
+                // Branch to the end of the innermost loop's continue block, which
+                // falls through to the iterator step / back-edge so the next
+                // iteration runs.
+                if let Some(loop_ctx) = ctx.loop_stack.last().copied() {
+                    func.instruction(&Instruction::Br(ctx.block_depth - loop_ctx.continue_level));
+                }
             }
         }
     }

--- a/src/ir/converter.rs
+++ b/src/ir/converter.rs
@@ -846,6 +846,12 @@ fn lower_function_body(stmts: &[Stmt], memory_layout: &mut MemoryLayout) -> Resu
 
                 ir_statements.push(IRStatement::While { condition, body });
             }
+            Stmt::Break(_) => {
+                ir_statements.push(IRStatement::Break);
+            }
+            Stmt::Continue(_) => {
+                ir_statements.push(IRStatement::Continue);
+            }
             Stmt::Expr(expr_stmt) => {
                 // Check for yield statements
                 if let Expr::Yield(yield_expr) = &*expr_stmt.value {

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -113,6 +113,10 @@ pub enum IRStatement {
         module_name: String,
         alias: Option<String>,
     },
+    // Loop control: `break` exits the innermost loop.
+    Break,
+    // Loop control: `continue` jumps to the next iteration of the innermost loop.
+    Continue,
 }
 
 /// Except handler for try-except statements


### PR DESCRIPTION
`break` and `continue` previously aborted compilation with "Unsupported statement type", so any loop needing an early exit or a skipped iteration could not compile.

Lower them to `IRStatement::Break`/`Continue` and emit WASM branches using a per-function block-depth counter plus a loop-context stack, so a `break`/`continue` nested inside `if`/`try` frames or inner loops targets the correct loop. Each loop body is now wrapped in an inner `block`: `continue` branches to its end and falls through to the iterator step (branching to the loop header would skip the step and spin forever), while `break` exits the loop's outer block.

Also fix an off-by-one in `for x in <list>`: the element load used a base address of `ptr + i*4` with load offset 0, so it read the leading length word as element 0 and dropped the last element. The load now uses a +4 offset and iterates the real elements.

Closes #23