### PR TITLE
fix(codegen): read strings and bytes back out of collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `break` and `continue` statements in `for` and `while` loops. Each loop body is wrapped in an inner block so `continue` falls through to the iterator step, and a block-depth counter plus loop-context stack compute the correct branch depth so break/continue nested inside `if`/`try` frames or nested loops target the right loop ([#23](https://github.com/anistark/waspy/issues/23))
+- Runtime bump allocator (`__alloc(size) -> ptr`) over a mutable global heap pointer that grows linear memory on demand (no `free`), emitted after the user functions; backs runtime-built strings/bytes such as concatenation results
 
 ### Fixed
 - `for x in <list>` read each element from `ptr + i*4` with load offset 0, loading the leading length word as element 0 and dropping the last element; the load now uses a `+4` offset so iteration sees the real elements
+- Reading a string/bytes value out of a list or tuple rebuilds its `(offset, length)` pair instead of emitting invalid WASM (a `local.set` stack underflow): each interned string/bytes blob is laid out as `[len:i32][bytes][nul?]` with its recorded offset pointing past the prefix, so the length is recovered via `load(offset - 4)`; the stored slot stays the interned offset, so offset-based membership and set de-duplication are unchanged
+- String/bytes concatenation (`+`) copies both operands into a freshly allocated, length-prefixed blob via `memory.copy`, replacing the placeholder that returned the left operand's offset with the combined length (correct only when literals happened to be adjacent in memory)
+- A string/bytes function return yields the value's offset rather than its length (a length-prefixed blob lets the caller recover the length via `load(offset - 4)`)
+- Binaryen optimization runs with the bulk-memory feature enabled so the `memory.copy` emitted by concatenation survives optimization instead of aborting it
 
 ## [0.10.0](https://github.com/anistark/waspy/releases/tag/v0.10.0) - 2026-06-15
 

--- a/src/compiler/context.rs
+++ b/src/compiler/context.rs
@@ -90,6 +90,10 @@ pub struct CompilationContext {
     /// grows monotonically across the whole module. A `Cell` because codegen
     /// holds `&CompilationContext` while allocating.
     pub collection_alloc_offset: Cell<u32>,
+    /// WASM function index of the runtime bump allocator `__alloc(size) -> ptr`.
+    /// Emitted after all user functions/methods, so callers (e.g. string/bytes
+    /// concatenation) reference it by this index. Set during module assembly.
+    pub alloc_func_index: u32,
 }
 
 impl CompilationContext {
@@ -109,6 +113,7 @@ impl CompilationContext {
             block_depth: 0,
             loop_stack: Vec::new(),
             collection_alloc_offset: Cell::new(0),
+            alloc_func_index: 0,
         }
     }
 

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -1,6 +1,9 @@
 use crate::compiler::context::{strlen_local_name, CompilationContext};
 use crate::compiler::function::{load_field_instr, lookup_field};
-use crate::ir::{IRBoolOp, IRCompareOp, IRConstant, IRExpr, IROp, IRType, IRUnaryOp, MemoryLayout};
+use crate::ir::{
+    IRBoolOp, IRCompareOp, IRConstant, IRExpr, IROp, IRType, IRUnaryOp, MemoryLayout,
+    STRING_LEN_PREFIX,
+};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
 
 // Helper to convert f64 to Ieee64
@@ -40,22 +43,47 @@ fn store_collection_word(func: &mut Function, elem_type: &IRType) {
     }
 }
 
-/// Load a 4-byte collection slot (address on top of the stack), widening f32
-/// float slots back to the f64 the rest of the compiler works with.
-fn load_collection_word(func: &mut Function, elem_type: &IRType) {
-    if matches!(elem_type, IRType::Float) {
-        func.instruction(&Instruction::F32Load(MemArg {
-            offset: 0,
-            align: 2,
-            memory_index: 0,
-        }));
-        func.instruction(&Instruction::F64PromoteF32);
-    } else {
-        func.instruction(&Instruction::I32Load(MemArg {
-            offset: 0,
-            align: 2,
-            memory_index: 0,
-        }));
+/// Load a collection slot (address on top of the stack) as a runtime value.
+///
+/// Floats are widened from their f32 slot back to f64. String/bytes slots hold
+/// only the value's offset, so the companion length is recovered from the blob's
+/// length prefix (`load(offset - STRING_LEN_PREFIX)`) and the `(offset, length)`
+/// pair the rest of the compiler expects is rebuilt; `scratch` is an i32 scratch
+/// local used to hold the offset while doing so. Everything else is a plain i32.
+fn load_collection_word(func: &mut Function, elem_type: &IRType, scratch: u32) {
+    match elem_type {
+        IRType::Float => {
+            func.instruction(&Instruction::F32Load(MemArg {
+                offset: 0,
+                align: 2,
+                memory_index: 0,
+            }));
+            func.instruction(&Instruction::F64PromoteF32);
+        }
+        IRType::String | IRType::Bytes => {
+            // Slot holds the offset; rebuild (offset, length).
+            func.instruction(&Instruction::I32Load(MemArg {
+                offset: 0,
+                align: 2,
+                memory_index: 0,
+            }));
+            func.instruction(&Instruction::LocalTee(scratch)); // keep offset, save it
+            func.instruction(&Instruction::LocalGet(scratch));
+            func.instruction(&Instruction::I32Const(STRING_LEN_PREFIX as i32));
+            func.instruction(&Instruction::I32Sub);
+            func.instruction(&Instruction::I32Load(MemArg {
+                offset: 0,
+                align: 2,
+                memory_index: 0,
+            }));
+        }
+        _ => {
+            func.instruction(&Instruction::I32Load(MemArg {
+                offset: 0,
+                align: 2,
+                memory_index: 0,
+            }));
+        }
     }
 }
 
@@ -189,45 +217,89 @@ pub fn emit_expr(
                         if (left_type == IRType::String && right_type == IRType::String)
                             || (left_type == IRType::Bytes && right_type == IRType::Bytes)
                         {
-                            // String/Bytes concatenation: stack has (left_offset, left_len, right_offset, right_len)
-                            // We need to return (concat_offset, concat_len)
-                            // Stack: (left_offset, left_len, right_offset, right_len)
+                            // String/Bytes concatenation. Stack on entry:
+                            //   (left_offset, left_len, right_offset, right_len)
+                            // A new `[len:i32][bytes][nul?]` blob is allocated at
+                            // runtime via `__alloc`, both operands are copied in
+                            // with `memory.copy`, and the result `(offset, len)`
+                            // (offset past the length prefix) is left on the
+                            // stack. Strings get a trailing NUL; bytes do not.
+                            let is_string = left_type == IRType::String;
+                            let prefix = STRING_LEN_PREFIX as i32;
 
-                            // Save right side to temps
                             func.instruction(&Instruction::LocalSet(ctx.temp_local + 1)); // right_len
                             func.instruction(&Instruction::LocalSet(ctx.temp_local + 2)); // right_offset
-
-                            // Stack: (left_offset, left_len)
-                            // Save left side to temps
                             func.instruction(&Instruction::LocalSet(ctx.temp_local + 3)); // left_len
                             func.instruction(&Instruction::LocalSet(ctx.temp_local + 4)); // left_offset
 
-                            // Calculate concatenated length = left_len + right_len
+                            // total_len = left_len + right_len
                             func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
                             func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
                             func.instruction(&Instruction::I32Add);
-                            func.instruction(&Instruction::LocalSet(ctx.temp_local)); // concat_len
+                            func.instruction(&Instruction::LocalSet(ctx.temp_local + 5)); // total_len
 
-                            // For runtime concatenation, we need to:
-                            // 1. Calculate where to put the result in memory
-                            // 2. Copy left string/bytes
-                            // 3. Copy right string/bytes
-                            // Since we don't have dynamic allocation, we use the end of current data
-                            // For now, we'll implement a simplified version that works for small data
+                            // block = __alloc(prefix + total_len [+ 1 for NUL])
+                            func.instruction(&Instruction::I32Const(prefix));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 5));
+                            func.instruction(&Instruction::I32Add);
+                            if is_string {
+                                func.instruction(&Instruction::I32Const(1));
+                                func.instruction(&Instruction::I32Add);
+                            }
+                            func.instruction(&Instruction::Call(ctx.alloc_func_index));
+                            func.instruction(&Instruction::LocalSet(ctx.temp_local + 6)); // block
 
-                            // Get left offset and length
+                            // Write the length prefix at the block start.
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 6));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 5));
+                            func.instruction(&Instruction::I32Store(MemArg {
+                                offset: 0,
+                                align: 2,
+                                memory_index: 0,
+                            }));
+
+                            // data_ptr = block + prefix (the value's offset)
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 6));
+                            func.instruction(&Instruction::I32Const(prefix));
+                            func.instruction(&Instruction::I32Add);
+                            func.instruction(&Instruction::LocalSet(ctx.temp_local + 6)); // data_ptr
+
+                            // memory.copy(data_ptr, left_offset, left_len)
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 6));
                             func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
                             func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                            func.instruction(&Instruction::MemoryCopy {
+                                src_mem: 0,
+                                dst_mem: 0,
+                            });
 
-                            // Stack: (left_offset, left_len)
-                            // The concatenated data will be stored after all current data
-                            // Use a heuristic: place result at a fixed high offset (TODO: improve)
-                            // For now, return a dummy concatenation using the left data as base
-                            // Drop the length and return (left_offset, concat_len)
-                            func.instruction(&Instruction::Drop);
-                            func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                            // memory.copy(data_ptr + left_len, right_offset, right_len)
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 6));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 3));
+                            func.instruction(&Instruction::I32Add);
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 2));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 1));
+                            func.instruction(&Instruction::MemoryCopy {
+                                src_mem: 0,
+                                dst_mem: 0,
+                            });
 
-                            // Stack: (left_offset, concat_len)
+                            // Strings are NUL-terminated; write it past the data.
+                            if is_string {
+                                func.instruction(&Instruction::LocalGet(ctx.temp_local + 6));
+                                func.instruction(&Instruction::LocalGet(ctx.temp_local + 5));
+                                func.instruction(&Instruction::I32Add);
+                                func.instruction(&Instruction::I32Const(0));
+                                func.instruction(&Instruction::I32Store8(MemArg {
+                                    offset: 0,
+                                    align: 0,
+                                    memory_index: 0,
+                                }));
+                            }
+
+                            // Result: (data_ptr, total_len)
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 6));
+                            func.instruction(&Instruction::LocalGet(ctx.temp_local + 5));
                             return left_type.clone();
                         }
                     }
@@ -1295,7 +1367,7 @@ pub fn emit_expr(
                     func.instruction(&Instruction::I32Add); // index*4 + 4
                     func.instruction(&Instruction::I32Add); // list_ptr + index*4 + 4
 
-                    load_collection_word(func, element_type.as_ref());
+                    load_collection_word(func, element_type.as_ref(), ctx.temp_local + 1);
 
                     element_type.as_ref().clone()
                 }
@@ -1406,7 +1478,7 @@ pub fn emit_expr(
                         IRType::Unknown
                     };
 
-                    load_collection_word(func, &elem_type);
+                    load_collection_word(func, &elem_type, ctx.temp_local + 1);
 
                     elem_type
                 }

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -420,7 +420,14 @@ pub fn compile_body(
         match stmt {
             IRStatement::Return(expr_opt) => {
                 if let Some(expr) = expr_opt {
-                    emit_expr(expr, func, ctx, memory_layout, None);
+                    let ty = emit_expr(expr, func, ctx, memory_layout, None);
+                    // A string/bytes value is an (offset, length) pair, but a
+                    // function returns a single word. Drop the length (on top)
+                    // and return the offset; the length-prefixed blob lets a
+                    // caller recover the length via `load(offset - 4)`.
+                    if matches!(ty, IRType::String | IRType::Bytes) {
+                        func.instruction(&Instruction::Drop);
+                    }
                 } else {
                     func.instruction(&Instruction::I32Const(0));
                 }

--- a/src/compiler/module.rs
+++ b/src/compiler/module.rs
@@ -1,10 +1,11 @@
 use crate::compiler::context::{ClassInfo, CompilationContext, COLLECTION_HEAP_BASE};
 use crate::compiler::function::{compile_function, resolve_return_type};
-use crate::ir::{IRBody, IRConstant, IRExpr, IRModule, IRStatement, IRType};
+use crate::ir::{IRBody, IRConstant, IRExpr, IRModule, IRStatement, IRType, STRING_LEN_PREFIX};
 use std::collections::HashMap;
 use wasm_encoder::{
-    CodeSection, ConstExpr, DataSection, ExportSection, FunctionSection, MemorySection, MemoryType,
-    Module, TypeSection, ValType,
+    BlockType, CodeSection, ConstExpr, DataSection, ExportSection, Function, FunctionSection,
+    GlobalSection, GlobalType, Instruction, MemorySection, MemoryType, Module, TypeSection,
+    ValType,
 };
 
 /// Map IR type to WebAssembly ValType
@@ -91,6 +92,66 @@ fn collect_self_fields(
     }
 }
 
+/// Build the runtime bump allocator `__alloc(size: i32) -> i32`.
+///
+/// The next-free pointer lives in global 0 (initialized to the post-codegen
+/// high-water mark). Each call rounds `size` up to 8 bytes, grows linear memory
+/// if the request would run past the current end, advances the global, and
+/// returns the old pointer. There is no `free`; this is a monotonic bump
+/// allocator backing runtime-built strings/bytes (e.g. concatenation results).
+fn build_alloc_function() -> Function {
+    // locals 1..4 (local 0 is the `size` parameter): aligned size, old ptr,
+    // new ptr, current memory size in bytes.
+    let mut f = Function::new([(4u32, ValType::I32)]);
+
+    // aligned = (size + 7) & ~7  -> local 1
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(7));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::I32Const(!7));
+    f.instruction(&Instruction::I32And);
+    f.instruction(&Instruction::LocalSet(1));
+
+    // old = global 0 -> local 2
+    f.instruction(&Instruction::GlobalGet(0));
+    f.instruction(&Instruction::LocalSet(2));
+
+    // new = old + aligned -> local 3
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::LocalSet(3));
+
+    // cur_bytes = memory.size * 65536 -> local 4
+    f.instruction(&Instruction::MemorySize(0));
+    f.instruction(&Instruction::I32Const(16));
+    f.instruction(&Instruction::I32Shl);
+    f.instruction(&Instruction::LocalSet(4));
+
+    // if new > cur_bytes: grow by ceil((new - cur_bytes) / 65536) pages
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32GtU);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::I32Const(65535));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::I32Const(16));
+    f.instruction(&Instruction::I32ShrU);
+    f.instruction(&Instruction::MemoryGrow(0));
+    f.instruction(&Instruction::Drop); // grow failure (-1) is left to trap on use
+    f.instruction(&Instruction::End);
+
+    // global 0 = new; return old
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::GlobalSet(0));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::End);
+    f
+}
+
 /// Compile an IR module into WebAssembly binary format
 pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     let mut module = Module::new();
@@ -144,6 +205,11 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         total_function_count += cls.methods.len();
     }
 
+    // The runtime allocator `__alloc` is appended after all user functions and
+    // methods, so it takes the next function (and type) index. Record it so
+    // codegen can emit `call $__alloc`.
+    ctx.alloc_func_index = total_function_count as u32;
+
     // Create function types for module functions
     for func in &ir_module.functions {
         // Map IR parameter types to WebAssembly types
@@ -173,13 +239,18 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         }
     }
 
+    // Type for the runtime allocator `__alloc(size: i32) -> i32`.
+    types.ty().function([ValType::I32], [ValType::I32]);
+
     module.section(&types);
 
-    // Build function section
+    // Build function section (one entry per user function/method, referencing
+    // the matching type, plus a trailing entry for `__alloc`).
     let mut functions = FunctionSection::new();
     for _ in 0..total_function_count {
         functions.function(functions.len());
     }
+    functions.function(total_function_count as u32); // __alloc
     module.section(&functions);
 
     // Export section - export both functions and memory
@@ -286,9 +357,12 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
     // Data section for string and bytes constants.
     let mut data = DataSection::new();
 
-    // String data lives from offset 0. Offsets are assigned sequentially as
-    // `len + 1` (a null terminator after each), so emitting the strings in
-    // offset order, each followed by a NUL, reproduces those exact offsets.
+    // String data lives from offset 0. Each blob is `[len:i32][bytes][nul]`;
+    // the recorded offset points at the bytes (past the length prefix), so
+    // emitting the strings in offset order — each prefixed by its length and
+    // followed by a NUL — reproduces those exact offsets. The prefix lets a
+    // string's length be recovered as `load(offset - 4)` when only its offset
+    // word survives (e.g. read back out of a collection slot).
     if !memory_layout.string_offsets.is_empty() {
         let mut offsets: Vec<(&String, u32)> = memory_layout
             .string_offsets
@@ -299,15 +373,16 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
 
         let mut all_strings = Vec::new();
         for (s, _) in offsets {
+            all_strings.extend_from_slice(&(s.len() as u32).to_le_bytes()); // length prefix
             all_strings.extend_from_slice(s.as_bytes());
             all_strings.push(0); // Null terminator
         }
         data.active(0, &ConstExpr::i32_const(0), all_strings);
     }
 
-    // Bytes data lives from `next_bytes_offset`'s base (32768). Offsets advance
-    // by exactly the byte length (no terminator), so the values are contiguous
-    // from the lowest assigned offset; emit them in offset order from there.
+    // Bytes data lives from `next_bytes_offset`'s base (32768). Each blob is
+    // `[len:i32][bytes]` (no terminator); the recorded offset points at the
+    // bytes, so the data segment starts one prefix before the lowest offset.
     if !memory_layout.bytes_offsets.is_empty() {
         let mut offsets: Vec<(&Vec<u8>, u32)> = memory_layout
             .bytes_offsets
@@ -316,9 +391,10 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
             .collect();
         offsets.sort_by_key(|(_b, offset)| *offset);
 
-        let base = offsets[0].1;
+        let base = offsets[0].1 - STRING_LEN_PREFIX;
         let mut all_bytes = Vec::new();
         for (b, _) in offsets {
+            all_bytes.extend_from_slice(&(b.len() as u32).to_le_bytes()); // length prefix
             all_bytes.extend_from_slice(b);
         }
         data.active(0, &ConstExpr::i32_const(base as i32), all_bytes);
@@ -342,12 +418,17 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         }
     }
 
+    // Runtime allocator, last so its index matches `ctx.alloc_func_index`.
+    codes.function(&build_alloc_function());
+
     // Memory must hold the static data (strings/bytes/object instances) plus
     // every collection region handed out during codegen. The collection heap
     // grows from COLLECTION_HEAP_BASE, so size memory to cover its high-water
-    // mark (at least the base region).
+    // mark (at least the base region). The runtime bump allocator starts just
+    // past that mark and grows memory on demand.
     let heap_end = COLLECTION_HEAP_BASE + ctx.collection_alloc_offset.get();
-    let min_pages = (((heap_end as u64) + 65535) / 65536).max(2);
+    let runtime_heap_base = (heap_end + 7) & !7;
+    let min_pages = (((runtime_heap_base as u64) + 65535) / 65536).max(2);
     let mut memories = MemorySection::new();
     memories.memory(MemoryType {
         minimum: min_pages,
@@ -357,10 +438,22 @@ pub fn compile_ir_module(ir_module: &IRModule) -> Vec<u8> {
         page_size_log2: None,
     });
 
-    // Section order follows the WASM spec: Memory (5), Export (7), Code (10),
-    // Data (11). Code must precede Data or strict validators (and Binaryen's
-    // reader) reject the module, which previously disabled optimization.
+    // Global 0: the runtime allocator's next-free pointer.
+    let mut globals = GlobalSection::new();
+    globals.global(
+        GlobalType {
+            val_type: ValType::I32,
+            mutable: true,
+            shared: false,
+        },
+        &ConstExpr::i32_const(runtime_heap_base as i32),
+    );
+
+    // Section order follows the WASM spec: Memory (5), Global (6), Export (7),
+    // Code (10), Data (11). Code must precede Data or strict validators (and
+    // Binaryen's reader) reject the module, which previously disabled optimization.
     module.section(&memories);
+    module.section(&globals);
     module.section(&exports);
     module.section(&codes);
     module.section(&data);

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -342,6 +342,13 @@ pub enum IRBoolOp {
     Or,  // or
 }
 
+/// Number of bytes reserved before each interned string/bytes blob to hold its
+/// length (an i32). A blob's recorded offset points just past this prefix, so
+/// `load(offset - STRING_LEN_PREFIX)` recovers its length even when only the
+/// offset word survives (e.g. read back out of a collection slot). Runtime
+/// strings built by `__alloc` use the same layout.
+pub const STRING_LEN_PREFIX: u32 = 4;
+
 /// Memory layout information for string and object storage
 #[derive(Debug, Clone)]
 pub struct MemoryLayout {
@@ -380,11 +387,14 @@ impl MemoryLayout {
             return offset;
         }
 
-        let offset = self.next_string_offset;
+        // Each blob is laid out as [len:i32][bytes...][nul]; the returned offset
+        // points at the bytes (past the length prefix), so the length is
+        // recoverable as load(offset - STRING_LEN_PREFIX).
+        let offset = self.next_string_offset + STRING_LEN_PREFIX;
         self.string_offsets.insert(s.to_string(), offset);
 
-        // Advance offset by string length + null terminator
-        self.next_string_offset += (s.len() + 1) as u32;
+        // Advance past the prefix, the bytes, and the null terminator.
+        self.next_string_offset += STRING_LEN_PREFIX + (s.len() + 1) as u32;
 
         offset
     }
@@ -395,11 +405,13 @@ impl MemoryLayout {
             return offset;
         }
 
-        let offset = self.next_bytes_offset;
+        // Same [len:i32][bytes...] layout as strings (no null terminator); the
+        // returned offset points at the bytes, past the length prefix.
+        let offset = self.next_bytes_offset + STRING_LEN_PREFIX;
         self.bytes_offsets.insert(b.to_vec(), offset);
 
-        // Advance offset by bytes length
-        self.next_bytes_offset += b.len() as u32;
+        // Advance past the prefix and the bytes.
+        self.next_bytes_offset += STRING_LEN_PREFIX + b.len() as u32;
 
         offset
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -809,6 +809,58 @@ mod collection_tests {
     }
 
     #[test]
+    fn string_read_back_from_list_has_length() {
+        // A string element stores only its offset; reading it back rebuilds the
+        // (offset, length) pair from the blob's length prefix. Previously this
+        // dropped the length, so binding it to a local emitted invalid WASM
+        // ("not enough arguments on the stack for local.set").
+        let src =
+            "def f() -> int:\n    xs = [\"alpha\", \"beta\", \"gamma\"]\n    w = xs[1]\n    return len(w)\n";
+        assert_eq!(call_i32(src, "f"), 4);
+    }
+
+    #[test]
+    fn string_read_back_from_tuple_has_length() {
+        let src =
+            "def f() -> int:\n    t = (\"one\", \"three\", \"x\")\n    w = t[1]\n    return len(w)\n";
+        assert_eq!(call_i32(src, "f"), 5);
+    }
+
+    #[test]
+    fn string_read_back_preserves_identity() {
+        // The recovered offset is the interned one, so membership (offset
+        // comparison) still finds the value pulled back out of the list.
+        let src = "def f() -> int:\n    xs = [\"alpha\", \"beta\", \"gamma\"]\n    w = xs[1]\n    if w in xs:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(src, "f"), 1);
+    }
+
+    #[test]
+    fn string_membership_unaffected_by_read_back() {
+        // Reading strings out of collections must not regress offset-based
+        // membership/dedup, which the length-prefix layout leaves untouched.
+        let present =
+            "def f() -> int:\n    xs = [\"a\", \"b\", \"c\"]\n    if \"b\" in xs:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(present, "f"), 1);
+        let absent =
+            "def f() -> int:\n    xs = [\"a\", \"b\", \"c\"]\n    if \"z\" in xs:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(absent, "f"), 0);
+        let set_dedup =
+            "def f() -> int:\n    s = {\"x\", \"y\", \"x\", \"z\"}\n    return len(s)\n";
+        assert_eq!(call_i32(set_dedup, "f"), 3);
+    }
+
+    #[test]
+    fn string_concatenation_round_trips() {
+        // Real runtime concatenation: `__alloc` a fresh blob and copy both
+        // operands in (was a placeholder that aliased the left operand).
+        let len = "def f() -> int:\n    a = \"foo\"\n    b = \"barbar\"\n    return len(a + b)\n";
+        assert_eq!(call_i32(len, "f"), 9);
+        // The concatenated string round-trips through a list slot too.
+        let via_list = "def f() -> int:\n    a = \"foo\"\n    b = \"bar\"\n    xs = [a + b]\n    w = xs[0]\n    return len(w)\n";
+        assert_eq!(call_i32(via_list, "f"), 6);
+    }
+
+    #[test]
     fn distinct_collections_do_not_alias() {
         // Both lists previously shared one address (base + local_count*100).
         let src =

--- a/src/optimize/wasm.rs
+++ b/src/optimize/wasm.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use binaryen::{CodegenConfig, Module};
+use binaryen::{ffi, CodegenConfig, Module};
+use std::os::raw::c_char;
 
 /// Optimize WebAssembly binary using Binaryen
 pub fn optimize_wasm(wasm_binary: &[u8]) -> Result<Vec<u8>> {
@@ -7,25 +8,33 @@ pub fn optimize_wasm(wasm_binary: &[u8]) -> Result<Vec<u8>> {
         return Ok(wasm_binary.to_vec());
     }
 
-    match Module::read(wasm_binary) {
-        Ok(mut module) => {
-            let config = CodegenConfig::default();
-
-            // Optimize with the config
-            module.optimize(&config);
-
-            // Get the optimized binary
-            let optimized_binary = module.write();
-
-            if optimized_binary.len() < 8 {
-                Ok(wasm_binary.to_vec())
-            } else {
-                Ok(optimized_binary)
-            }
+    unsafe {
+        let raw =
+            ffi::BinaryenModuleSafeRead(wasm_binary.as_ptr() as *const c_char, wasm_binary.len());
+        if raw.is_null() {
+            // If the module can't be read, return the original binary.
+            return Ok(wasm_binary.to_vec());
         }
-        Err(_) => {
-            // If optimization fails, return the original binary
+
+        // The runtime string/bytes allocator emits `memory.copy`, which lives in
+        // the bulk-memory feature. Binaryen's optimizer asserts if that feature
+        // isn't enabled on the module, so turn it on before optimizing.
+        let features = ffi::BinaryenModuleGetFeatures(raw) | ffi::BinaryenFeatureBulkMemory();
+        ffi::BinaryenModuleSetFeatures(raw, features);
+
+        let mut module = Module::from_raw(raw);
+        let config = CodegenConfig::default();
+
+        // Optimize with the config
+        module.optimize(&config);
+
+        // Get the optimized binary
+        let optimized_binary = module.write();
+
+        if optimized_binary.len() < 8 {
             Ok(wasm_binary.to_vec())
+        } else {
+            Ok(optimized_binary)
         }
     }
 }


### PR DESCRIPTION
Reading a string/bytes value out of a list or tuple emitted invalid WASM. Collections store one word per element (the value's offset), but a string is an (offset, length) pair, so binding `w = words[1]` supplied one stack value where the assignment expected two — a `local.set` stack underflow, so the module would not even instantiate.

Interned string/bytes blobs are now laid out as `[len:i32][bytes][nul?]` with the recorded offset pointing past the length prefix, so a value's length is recoverable as `load(offset - 4)`. The stored collection slot stays the interned offset, so offset-based membership (`x in xs`) and set de-duplication are unaffected.

Two supporting changes were required:

- A runtime bump allocator `__alloc(size) -> ptr` (a mutable global heap pointer that grows linear memory on demand; no `free`), so runtime-built strings get the same length-prefixed layout. String/bytes `+` now does a real `memory.copy` of both operands into a fresh blob, replacing a placeholder that returned the left operand's offset with the combined length and only worked when literals happened to sit adjacent in memory.
- A string/bytes function return now yields the value's offset rather than its length (the prefix lets the caller recover the length).

Binaryen optimization runs with the bulk-memory feature enabled so the `memory.copy` emitted by concatenation survives optimization.

Remaining edges: dict-value string read-back, a slice result stored into a collection, and general string `==` (compares one word).