### PR TITLE
fix(codegen): correct string/bytes equality and length recovery

### DIFF
--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -712,6 +712,107 @@ pub fn emit_expr(
             let left_type = emit_expr(left, func, ctx, memory_layout, None);
             let right_type = emit_expr(right, func, ctx, memory_layout, Some(&left_type));
 
+            // String/bytes comparison: each operand is an (offset, length) pair,
+            // so the stack holds (left_off, left_len, right_off, right_len). The
+            // numeric paths below assume single-word scalars and would compare
+            // only the top word (the right operand's length) while stranding the
+            // left pair. Handle str/bytes here: Eq/NotEq compare contents
+            // byte-for-byte — interned constants share an offset, but
+            // runtime-built strings (concatenation, slices) do not, so an offset
+            // compare is insufficient. Ordering/identity comparisons aren't
+            // supported yet and yield a constant after balancing the stack. See #90.
+            if matches!(left_type, IRType::String | IRType::Bytes)
+                && matches!(right_type, IRType::String | IRType::Bytes)
+            {
+                match op {
+                    IRCompareOp::Eq | IRCompareOp::NotEq => {
+                        let left_off = ctx.temp_local;
+                        let left_len = ctx.temp_local + 1;
+                        let right_off = ctx.temp_local + 2;
+                        let right_len = ctx.temp_local + 3;
+                        let result = ctx.temp_local + 4;
+                        let counter = ctx.temp_local + 5;
+
+                        func.instruction(&Instruction::LocalSet(right_len));
+                        func.instruction(&Instruction::LocalSet(right_off));
+                        func.instruction(&Instruction::LocalSet(left_len));
+                        func.instruction(&Instruction::LocalSet(left_off));
+
+                        // result = 1 (equal until a mismatch is found)
+                        func.instruction(&Instruction::I32Const(1));
+                        func.instruction(&Instruction::LocalSet(result));
+
+                        func.instruction(&Instruction::Block(BlockType::Empty));
+                        // Different lengths => not equal.
+                        func.instruction(&Instruction::LocalGet(left_len));
+                        func.instruction(&Instruction::LocalGet(right_len));
+                        func.instruction(&Instruction::I32Ne);
+                        func.instruction(&Instruction::If(BlockType::Empty));
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::LocalSet(result));
+                        func.instruction(&Instruction::Br(1)); // exit outer block
+                        func.instruction(&Instruction::End);
+
+                        // Compare bytes until the end or a mismatch.
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::LocalSet(counter));
+                        func.instruction(&Instruction::Loop(BlockType::Empty));
+                        // counter >= len => every byte matched; result stays 1.
+                        func.instruction(&Instruction::LocalGet(counter));
+                        func.instruction(&Instruction::LocalGet(left_len));
+                        func.instruction(&Instruction::I32GeS);
+                        func.instruction(&Instruction::BrIf(1)); // exit outer block
+                                                                 // left[counter]
+                        func.instruction(&Instruction::LocalGet(left_off));
+                        func.instruction(&Instruction::LocalGet(counter));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Load8U(MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        // right[counter]
+                        func.instruction(&Instruction::LocalGet(right_off));
+                        func.instruction(&Instruction::LocalGet(counter));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Load8U(MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                        func.instruction(&Instruction::I32Ne);
+                        func.instruction(&Instruction::If(BlockType::Empty));
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::LocalSet(result));
+                        func.instruction(&Instruction::Br(2)); // exit outer block
+                        func.instruction(&Instruction::End);
+                        // counter += 1
+                        func.instruction(&Instruction::LocalGet(counter));
+                        func.instruction(&Instruction::I32Const(1));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::LocalSet(counter));
+                        func.instruction(&Instruction::Br(0)); // continue loop
+                        func.instruction(&Instruction::End); // loop
+                        func.instruction(&Instruction::End); // block
+
+                        func.instruction(&Instruction::LocalGet(result));
+                        if matches!(op, IRCompareOp::NotEq) {
+                            func.instruction(&Instruction::I32Eqz);
+                        }
+                    }
+                    _ => {
+                        // Ordering/identity on str/bytes isn't supported yet; drop
+                        // both (offset, length) pairs and yield a constant.
+                        func.instruction(&Instruction::Drop);
+                        func.instruction(&Instruction::Drop);
+                        func.instruction(&Instruction::Drop);
+                        func.instruction(&Instruction::Drop);
+                        func.instruction(&Instruction::I32Const(0));
+                    }
+                }
+                return IRType::Bool;
+            }
+
             // Handle type coercion for comparison
             if left_type == IRType::Float && right_type == IRType::Int {
                 func.instruction(&Instruction::F64ConvertI32S);
@@ -1453,8 +1554,21 @@ pub fn emit_expr(
                     func.instruction(&Instruction::End);
                     func.instruction(&Instruction::End);
 
-                    // Push the looked-up value (0 if the key was not found)
+                    // Push the looked-up value (0 if the key was not found).
                     func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                    // For string/bytes values the word is the blob offset; rebuild
+                    // the (offset, length) pair from the length prefix, matching
+                    // list/tuple read-back in `load_collection_word`. See #91.
+                    if matches!(value_type.as_ref(), IRType::String | IRType::Bytes) {
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local + 4));
+                        func.instruction(&Instruction::I32Const(STRING_LEN_PREFIX as i32));
+                        func.instruction(&Instruction::I32Sub);
+                        func.instruction(&Instruction::I32Load(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
+                    }
 
                     value_type.as_ref().clone()
                 }
@@ -1588,10 +1702,74 @@ pub fn emit_expr(
                         func.instruction(&Instruction::Drop);
                     }
 
-                    // Result: (new_offset = offset + lo, new_length)
+                    // A slice's bytes live inside the source blob, so its offset
+                    // points partway into that blob rather than past a length
+                    // prefix. Allocate a fresh `[len:i32][bytes][nul?]` blob and
+                    // copy the slice into it (mirroring concatenation) so the
+                    // value carries a recoverable length prefix — the layout the
+                    // rest of the compiler assumes for collection read-back
+                    // (`load(offset - 4)`). See #92. `scratch` holds new_length.
+                    let is_string = matches!(container_type, IRType::String);
+                    let prefix = STRING_LEN_PREFIX as i32;
+                    let src = ctx.temp_local; // slice source offset
+                    let blk = ctx.temp_local + 1; // allocated block / data ptr
+
+                    // src = offset + lo
                     func.instruction(&Instruction::LocalGet(off));
                     func.instruction(&Instruction::LocalGet(lo));
                     func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalSet(src));
+
+                    // block = __alloc(prefix + new_length [+ 1 for NUL])
+                    func.instruction(&Instruction::I32Const(prefix));
+                    func.instruction(&Instruction::LocalGet(scratch));
+                    func.instruction(&Instruction::I32Add);
+                    if is_string {
+                        func.instruction(&Instruction::I32Const(1));
+                        func.instruction(&Instruction::I32Add);
+                    }
+                    func.instruction(&Instruction::Call(ctx.alloc_func_index));
+                    func.instruction(&Instruction::LocalSet(blk));
+
+                    // Write the length prefix at the block start.
+                    func.instruction(&Instruction::LocalGet(blk));
+                    func.instruction(&Instruction::LocalGet(scratch));
+                    func.instruction(&Instruction::I32Store(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    }));
+
+                    // data_ptr = block + prefix (the value's offset)
+                    func.instruction(&Instruction::LocalGet(blk));
+                    func.instruction(&Instruction::I32Const(prefix));
+                    func.instruction(&Instruction::I32Add);
+                    func.instruction(&Instruction::LocalSet(blk)); // data_ptr
+
+                    // memory.copy(data_ptr, src, new_length)
+                    func.instruction(&Instruction::LocalGet(blk));
+                    func.instruction(&Instruction::LocalGet(src));
+                    func.instruction(&Instruction::LocalGet(scratch));
+                    func.instruction(&Instruction::MemoryCopy {
+                        src_mem: 0,
+                        dst_mem: 0,
+                    });
+
+                    // Strings are NUL-terminated; write it past the data.
+                    if is_string {
+                        func.instruction(&Instruction::LocalGet(blk));
+                        func.instruction(&Instruction::LocalGet(scratch));
+                        func.instruction(&Instruction::I32Add);
+                        func.instruction(&Instruction::I32Const(0));
+                        func.instruction(&Instruction::I32Store8(MemArg {
+                            offset: 0,
+                            align: 0,
+                            memory_index: 0,
+                        }));
+                    }
+
+                    // Result: (data_ptr, new_length)
+                    func.instruction(&Instruction::LocalGet(blk));
                     func.instruction(&Instruction::LocalGet(scratch));
 
                     container_type.clone()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1056,4 +1056,63 @@ mod collection_tests {
         // underflowed the stack; it now resolves the submodule attribute.
         instantiate("import os\ndef f():\n    print(\"sep:\", os.path.sep)\n");
     }
+
+    #[test]
+    fn string_equality_compares_contents() {
+        // `==`/`!=` on str/bytes previously fell through to the integer path,
+        // which compared only the top word (the right operand's length) and
+        // stranded the left pair, so even equal strings compared unequal (#90).
+        let eq =
+            "def f() -> int:\n    a = \"hello\"\n    b = \"hello\"\n    if a == b:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(eq, "f"), 1);
+        let ne_same =
+            "def f() -> int:\n    a = \"hello\"\n    b = \"hello\"\n    if a != b:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(ne_same, "f"), 0);
+        let neq =
+            "def f() -> int:\n    a = \"hello\"\n    b = \"world\"\n    if a == b:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(neq, "f"), 0);
+        // Different lengths short-circuit before the byte loop.
+        let diff_len =
+            "def f() -> int:\n    a = \"hi\"\n    b = \"hello\"\n    if a == b:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(diff_len, "f"), 0);
+        // A runtime-built operand (concatenation) has a distinct offset, so a
+        // content compare — not an offset compare — is required.
+        let runtime =
+            "def f() -> int:\n    a = \"foo\" + \"bar\"\n    b = \"foobar\"\n    if a == b:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(runtime, "f"), 1);
+        let bytes_eq =
+            "def f() -> int:\n    a = b\"abc\"\n    b = b\"abc\"\n    if a == b:\n        return 1\n    return 0\n";
+        assert_eq!(call_i32(bytes_eq, "f"), 1);
+    }
+
+    #[test]
+    fn dict_string_value_read_back_has_length() {
+        // Reading a str/bytes value out of a dict dropped its length (#91): the
+        // matched value word is the blob offset, so rebuild (offset, length)
+        // from the length prefix like list/tuple read-back does.
+        let src =
+            "def f() -> int:\n    d = {1: \"value\", 2: \"xy\"}\n    w = d[1]\n    return len(w)\n";
+        assert_eq!(call_i32(src, "f"), 5);
+        let other =
+            "def f() -> int:\n    d = {1: \"value\", 2: \"xy\"}\n    w = d[2]\n    return len(w)\n";
+        assert_eq!(call_i32(other, "f"), 2);
+    }
+
+    #[test]
+    fn string_slice_into_collection_has_length() {
+        // A slice's offset points into the source blob, not past a fresh length
+        // prefix, so collection read-back (load(offset - 4)) read the source's
+        // length. Slicing now allocates a prefixed blob (#92).
+        let into_list =
+            "def f() -> int:\n    s = \"hello world\"\n    part = s[0:5]\n    xs = [part]\n    w = xs[0]\n    return len(w)\n";
+        assert_eq!(call_i32(into_list, "f"), 5);
+        let bytes_into_tuple =
+            "def f() -> int:\n    b = b\"hello world\"\n    part = b[6:11]\n    t = (part,)\n    w = t[0]\n    return len(w)\n";
+        assert_eq!(call_i32(bytes_into_tuple, "f"), 5);
+        // The relocated blob still holds the right bytes (bytes indexing
+        // returns the byte value; string indexing would return a char offset).
+        let content =
+            "def f() -> int:\n    b = b\"hello world\"\n    part = b[6:11]\n    return part[0]\n";
+        assert_eq!(call_i32(content, "f"), 119); // 'w'
+    }
 }


### PR DESCRIPTION
A str/bytes value is an (offset, length) pair, and every interned or runtime-built blob is laid out as `[len:i32][bytes][nul?]` so the length is recoverable as `load(offset - 4)`. Three paths broke that contract:

- `==`/`!=` on str/bytes fell through to the integer compare, which matched only the top word (the right operand's length) and stranded the left pair, so `"hello" == "hello"` was False. Add a String/Bytes branch that compares length then bytes; interned constants and runtime-built strings (concatenation, slices) now compare by content.

- Reading a str/bytes value out of a dict pushed the matched word raw, dropping the length, so `len(d[k])` was wrong. Rebuild (offset, length) from the prefix as list/tuple read-back already does.

- A slice's offset points into the source blob rather than past a fresh prefix, so storing one in a collection read the source's length back. Slicing now `__alloc`s a prefixed blob and `memory.copy`s the slice in, mirroring concatenation, so every runtime value carries its own prefix.

Ordering (`<`/`>`) on str/bytes remains unsupported. Adds runtime regression tests for all three paths.

Fixes #90, #91, #92