### PR TITLE
fix(codegen): string-typed parameters and raise with an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-...
+
+### Added
+- Integration test harness (`tests/integration/`, `tests/utils/`, registered as the `integration_examples` test target): compiles every `examples/*.py`, validates and instantiates the module with `wasmi`, and asserts runtime results (e.g. `break`/`continue` and multi-file cross-calls). The sweep immediately surfaced the two parameter/`raise` fixes below
+
+### Fixed
+- String/bytes function parameters now form a complete `(offset, length)` pair. Referencing a `str`/`bytes` parameter (e.g. `op == "add"`) pushed only its offset, so consumers like `==` underflowed the stack into invalid WASM; the length is recovered from the blob prefix (`load(offset - 4)`) when there is no companion length local. Passing a string/bytes value as an argument to a user function now narrows it to the single offset word each parameter slot holds (the callee recovers the length), fixing an out-of-bounds read that previously passed the length as the offset
+- `raise ExceptionType(arg)` (e.g. `raise ValueError("msg")`) emitted the constructor call and left its argument on the stack, producing invalid WASM ("values remaining on stack"); the raised exception is now resolved to its integer type code by name, shared with the `except` handler dispatch so the two cannot diverge
 
 ## [0.11.0](https://github.com/anistark/waspy/releases/tag/v0.11.0) - 2026-06-27
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ required-features = ["wasm-plugin"]
 name = "verbose_debug_demo"
 path = "examples/verbose_debug_demo.rs"
 
+# Integration tests (tests/ subdirectories are not auto-discovered by Cargo)
+[[test]]
+name = "integration_examples"
+path = "tests/integration/examples.rs"
+
 # Plugin metadata following wasmrust pattern
 [package.metadata.wasm_plugin]
 name = "python"

--- a/src/compiler/expression.rs
+++ b/src/compiler/expression.rs
@@ -177,12 +177,27 @@ pub fn emit_expr(
                 let index = local_info.index;
                 let var_type = local_info.var_type.clone();
                 func.instruction(&Instruction::LocalGet(index));
-                // String/bytes locals hold only the offset; push the length from
-                // the companion local to rebuild the (offset, length) pair the
-                // rest of the pipeline expects.
+                // String/bytes values are an (offset, length) pair but the local
+                // holds only the offset; push the length to rebuild the pair the
+                // rest of the pipeline expects. A local assigned in the body has a
+                // companion length local; a str/bytes *parameter* does not, so its
+                // length is recovered from the blob prefix via
+                // load(offset - STRING_LEN_PREFIX). Without this, referencing a
+                // string parameter left one word on the stack instead of two,
+                // underflowing later consumers (e.g. `==`) into invalid WASM.
                 if matches!(var_type, IRType::String | IRType::Bytes) {
                     if let Some(len_idx) = ctx.get_local_index(&strlen_local_name(name)) {
                         func.instruction(&Instruction::LocalGet(len_idx));
+                    } else {
+                        func.instruction(&Instruction::LocalTee(ctx.temp_local));
+                        func.instruction(&Instruction::LocalGet(ctx.temp_local));
+                        func.instruction(&Instruction::I32Const(STRING_LEN_PREFIX as i32));
+                        func.instruction(&Instruction::I32Sub);
+                        func.instruction(&Instruction::I32Load(MemArg {
+                            offset: 0,
+                            align: 2,
+                            memory_index: 0,
+                        }));
                     }
                 }
                 var_type
@@ -965,10 +980,21 @@ pub fn emit_expr(
                 return IRType::Class(function_name.clone());
             }
 
-            // Push arguments onto the stack in order
+            // Push arguments onto the stack in order. For a call to a known user
+            // function, a string/bytes argument must be narrowed to its single
+            // offset word: each parameter is one i32 slot, so the callee recovers
+            // the length from the blob prefix (load(offset - STRING_LEN_PREFIX))
+            // rather than receiving it as a second word. Without this drop the
+            // length (top of the pair) is passed as the offset, so the callee
+            // loads out of bounds. Built-in calls keep the full (offset, length)
+            // pair their lowering expects.
+            let is_user_fn = ctx.get_function_info(function_name.as_str()).is_some();
             let mut arg_types = Vec::new();
             for arg in arguments {
                 let arg_type = emit_expr(arg, func, ctx, memory_layout, None);
+                if is_user_fn && matches!(arg_type, IRType::String | IRType::Bytes) {
+                    func.instruction(&Instruction::Drop);
+                }
                 arg_types.push(arg_type);
             }
 

--- a/src/compiler/function.rs
+++ b/src/compiler/function.rs
@@ -79,6 +79,22 @@ pub fn compile_function(
     func
 }
 
+/// Map a built-in exception type name to the integer code used by the
+/// try/except dispatch. Shared by `raise` and the handler matching so the two
+/// always agree. Unknown names get a sentinel that no specific handler matches.
+fn exception_type_code(name: &str) -> i32 {
+    match name {
+        "ZeroDivisionError" => 1,
+        "ValueError" => 2,
+        "TypeError" => 3,
+        "KeyError" => 4,
+        "IndexError" => 5,
+        "AttributeError" => 6,
+        "RuntimeError" => 7,
+        _ => 99,
+    }
+}
+
 /// Resolve a class field to its `(byte offset, value type)`, if known.
 pub(crate) fn lookup_field(
     ctx: &CompilationContext,
@@ -571,12 +587,24 @@ pub fn compile_body(
                     .unwrap_or_else(|| ctx.add_local("__exception_type", IRType::Int));
 
                 if let Some(exc_expr) = exception {
-                    // Evaluate exception expression to get exception code/type
-                    emit_expr(exc_expr, func, ctx, memory_layout, None);
-                    // Store as exception type code
+                    // Resolve the exception to its type code by name — the same
+                    // table the handler dispatch uses — instead of emitting the
+                    // expression. We do not model exception objects, and emitting
+                    // a constructor like `ValueError("msg")` would leave its string
+                    // argument on the stack (invalid WASM). Both a bare name
+                    // (`raise ValueError`) and a constructor call
+                    // (`raise ValueError("msg")`) resolve by name.
+                    let code = match exc_expr {
+                        IRExpr::FunctionCall { function_name, .. } => {
+                            exception_type_code(function_name)
+                        }
+                        IRExpr::Variable(name) | IRExpr::Param(name) => exception_type_code(name),
+                        _ => 0,
+                    };
+                    func.instruction(&Instruction::I32Const(code));
                     func.instruction(&Instruction::LocalSet(exception_type_idx));
                 } else {
-                    // Generic exception code
+                    // Bare `raise`: generic exception code.
                     func.instruction(&Instruction::I32Const(0));
                     func.instruction(&Instruction::LocalSet(exception_type_idx));
                 }
@@ -1072,18 +1100,8 @@ pub fn compile_body(
                         func.instruction(&Instruction::I32Const(0));
                         func.instruction(&Instruction::LocalSet(exception_flag_idx));
                     } else if let Some(exc_type) = &handler.exception_type {
-                        // Typed exception handler
-                        // Map exception type names to codes
-                        let exc_code = match exc_type.as_str() {
-                            "ZeroDivisionError" => 1,
-                            "ValueError" => 2,
-                            "TypeError" => 3,
-                            "KeyError" => 4,
-                            "IndexError" => 5,
-                            "AttributeError" => 6,
-                            "RuntimeError" => 7,
-                            _ => 99, // Unknown exception type
-                        };
+                        // Typed exception handler: match by the shared type code.
+                        let exc_code = exception_type_code(exc_type.as_str());
 
                         func.instruction(&Instruction::Block(BlockType::Empty));
                         // This per-handler block wraps the handler body.

--- a/tests/integration/examples.rs
+++ b/tests/integration/examples.rs
@@ -1,0 +1,131 @@
+//! Integration coverage for the bundled `examples/*.py`.
+//!
+//! Tiers:
+//!   1. Every standalone example must compile to a valid, instantiable WASM
+//!      module. This is the "invalid / unrunnable module" class of regression
+//!      that the 0.10.0 correctness pass fixed; the sweep keeps it fixed and any
+//!      new example is covered automatically.
+//!   2. Multi-file compilation produces a valid module and cross-file calls run.
+//!   3. Two codegen defects this harness surfaced — a `str`-typed function
+//!      parameter compared with `==`, and `raise ExceptionType(arg)` — have
+//!      dedicated regression tests.
+//!   4. The 0.11.0 headline feature — `break` / `continue` — asserts concrete
+//!      runtime results by calling the exported functions of
+//!      `examples/loop_control.py`.
+
+#[path = "../utils/harness.rs"]
+mod harness;
+
+use harness::{
+    call_i32, call_i32_2, example_python_files, instantiate_wasm, read_example, try_compile,
+    try_compile_multi, try_instantiate, MULTI_FILE_ONLY,
+};
+
+/// Every standalone-compilable example compiles, validates, and instantiates.
+/// Multi-file examples are excluded (and covered by their own test below).
+/// Failures are collected so the report lists every broken example, not just
+/// the first.
+#[test]
+fn all_examples_compile_and_instantiate() {
+    let mut failures = Vec::new();
+    for path in example_python_files() {
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        if MULTI_FILE_ONLY.contains(&name.as_str()) {
+            continue;
+        }
+        let source = std::fs::read_to_string(&path).expect("read example file");
+        let result = try_compile(&source).and_then(|wasm| try_instantiate(&wasm));
+        if let Err(err) = result {
+            failures.push(format!("{name}: {err}"));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{} example(s) failed to compile + instantiate:\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+/// The multi-file demo compiles `basic_operations.py` + `calculator.py` into a
+/// single module (calculator depends on the other file) and runs functions that
+/// cross the file boundary. `complex_calculation(x, y)` computes
+/// `(x + y) * (x - y)`, so `(5, 3) == 16`; `calculate_factorial(5) == 120`
+/// exercises cross-file recursion.
+#[test]
+fn calculator_multi_file_compiles_and_runs() {
+    let basic = read_example("basic_operations.py");
+    let calculator = read_example("calculator.py");
+    let wasm = try_compile_multi(&[
+        ("basic_operations.py", &basic),
+        ("calculator.py", &calculator),
+    ])
+    .expect("multi-file compilation");
+    let (instance, mut store) = instantiate_wasm(&wasm);
+    let complex = instance
+        .get_typed_func::<(i32, i32), i32>(&store, "complex_calculation")
+        .expect("exported complex_calculation");
+    assert_eq!(complex.call(&mut store, (5, 3)).expect("call"), 16);
+    let factorial = instance
+        .get_typed_func::<i32, i32>(&store, "calculate_factorial")
+        .expect("exported calculate_factorial");
+    assert_eq!(factorial.call(&mut store, 5).expect("call"), 120);
+}
+
+/// Regression test for the `str`-parameter bug `calculator.py` surfaced: a
+/// function with a `str` parameter compared via `==`, called with a string
+/// literal. Both layers must work — the call narrows the string argument to its
+/// offset word, and the callee recovers the length from the blob prefix to run
+/// the byte-for-byte comparison. `classify` returns 1 for "add", 2 for "sub",
+/// 0 otherwise; the no-arg entry points make it callable without host-side
+/// string marshalling.
+#[test]
+fn str_parameter_equality_runs() {
+    let src = "def classify(op: str) -> int:\n    if op == \"add\":\n        return 1\n    if op == \"sub\":\n        return 2\n    return 0\n\ndef check_add() -> int:\n    return classify(\"add\")\n\ndef check_sub() -> int:\n    return classify(\"sub\")\n\ndef check_other() -> int:\n    return classify(\"xyz\")\n";
+    assert_eq!(call_i32(src, "check_add"), 1);
+    assert_eq!(call_i32(src, "check_sub"), 2);
+    assert_eq!(call_i32(src, "check_other"), 0);
+}
+
+/// Regression test for the `raise ExceptionType(arg)` bug `exceptions.py`
+/// surfaced: raising a built-in exception constructed with an argument
+/// (`raise ValueError("never")`) must not leave the argument on the stack. The
+/// exception is resolved to its type code by name, so the module is valid and
+/// instantiates. The `try` returns 7 before the (never-taken) handler.
+#[test]
+fn raise_with_argument_is_valid() {
+    let src = "def guard() -> int:\n    try:\n        return 7\n    except ValueError:\n        raise ValueError(\"never\")\n    finally:\n        done = 1\n    return 0\n";
+    assert_eq!(call_i32(src, "guard"), 7);
+}
+
+/// `break` exits the loop early: summing `range(100)` but breaking at `i == 5`
+/// yields 0 + 1 + 2 + 3 + 4 = 10.
+#[test]
+fn break_exits_loop_early() {
+    let src = read_example("loop_control.py");
+    assert_eq!(call_i32(&src, "sum_until_five"), 10);
+}
+
+/// `continue` skips the rest of the body: summing the odd numbers below ten
+/// yields 1 + 3 + 5 + 7 + 9 = 25.
+#[test]
+fn continue_skips_iteration() {
+    let src = read_example("loop_control.py");
+    assert_eq!(call_i32(&src, "sum_odds_below_ten"), 25);
+}
+
+/// `break` / `continue` inside a `while True` loop: the first multiple of 3
+/// strictly greater than 10 is 12.
+#[test]
+fn break_continue_in_while_loop() {
+    let src = read_example("loop_control.py");
+    assert_eq!(call_i32_2(&src, "first_multiple_over", 10, 3), 12);
+}
+
+/// `break` exits only the innermost loop: the inner loop breaks at `j == 1`
+/// after one increment, across three outer iterations, so the count is 3.
+#[test]
+fn break_exits_innermost_loop_only() {
+    let src = read_example("loop_control.py");
+    assert_eq!(call_i32(&src, "count_inner_breaks"), 3);
+}

--- a/tests/utils/harness.rs
+++ b/tests/utils/harness.rs
@@ -1,0 +1,130 @@
+//! Shared helpers for the integration test suite.
+//!
+//! These drive the public API exactly as a downstream user would: compile a
+//! Python source string (or a bundled `examples/*.py` file) to WASM, validate
+//! it, instantiate it with `wasmi`, and call exported functions. Compiled
+//! waspy modules have no host imports, so an empty `Linker` is sufficient and
+//! instantiation also exercises the start and data sections.
+//!
+//! The panicking helpers (`compile`, `instantiate`, `call_i32`, …) mirror the
+//! in-crate test helpers in `src/lib.rs` and are for assertions with a known
+//! expected result. The `try_*` variants return `Result` so a broad sweep can
+//! collect every failure instead of aborting on the first.
+
+use std::path::{Path, PathBuf};
+
+use wasmi::{Engine, Instance, Linker, Store};
+use waspy::{
+    compile_multiple_python_files_with_options, compile_python_to_wasm_with_options,
+    CompilerOptions,
+};
+
+/// Examples that are not meant to be compiled on their own: they call functions
+/// defined in a sibling file and only form a valid module when compiled
+/// together (see `examples/multi_file_compiler.rs`). The standalone sweep skips
+/// these; `calculator_multi_file_compiles_and_runs` covers them combined.
+pub const MULTI_FILE_ONLY: &[&str] = &["calculator.py"];
+
+/// Absolute path to the repository's `examples/` directory.
+pub fn examples_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("examples")
+}
+
+/// Every `examples/*.py` file, sorted for stable, reproducible test output.
+pub fn example_python_files() -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(examples_dir())
+        .expect("read examples/ directory")
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("py"))
+        .collect();
+    files.sort();
+    files
+}
+
+/// Read a bundled example by file name (e.g. `"loop_control.py"`).
+pub fn read_example(file_name: &str) -> String {
+    std::fs::read_to_string(examples_dir().join(file_name))
+        .unwrap_or_else(|e| panic!("read example {file_name}: {e}"))
+}
+
+/// Compile a Python source string to an unoptimized WASM module, returning the
+/// error as a string on failure. Optimization is off so a failure points at
+/// codegen rather than at Binaryen.
+pub fn try_compile(source: &str) -> Result<Vec<u8>, String> {
+    let options = CompilerOptions {
+        optimize: false,
+        ..CompilerOptions::default()
+    };
+    compile_python_to_wasm_with_options(source, &options).map_err(|e| e.to_string())
+}
+
+/// Validate the bytes as a WASM module and instantiate them under an empty
+/// linker, returning the error as a string on failure. Validation checks
+/// structure, types, and stack balance; instantiation then runs the start
+/// function and materializes the data section.
+pub fn try_instantiate(wasm: &[u8]) -> Result<(), String> {
+    let engine = Engine::default();
+    let module = wasmi::Module::new(&engine, wasm).map_err(|e| format!("validate: {e}"))?;
+    let mut store = Store::new(&engine, ());
+    Linker::<()>::new(&engine)
+        .instantiate(&mut store, &module)
+        .map_err(|e| format!("instantiate: {e}"))?
+        .start(&mut store)
+        .map_err(|e| format!("start: {e}"))?;
+    Ok(())
+}
+
+/// Compile several Python files into one module, returning the error as a
+/// string on failure. `sources` is `(file_name, source)` pairs.
+pub fn try_compile_multi(sources: &[(&str, &str)]) -> Result<Vec<u8>, String> {
+    let options = CompilerOptions {
+        optimize: false,
+        ..CompilerOptions::default()
+    };
+    compile_multiple_python_files_with_options(sources, &options).map_err(|e| e.to_string())
+}
+
+/// Compile a source string, asserting success.
+pub fn compile(source: &str) -> Vec<u8> {
+    try_compile(source).expect("compilation")
+}
+
+/// Instantiate already-built WASM bytes, asserting validation and start
+/// succeed. Returns the live instance and store so a test can call exports.
+pub fn instantiate_wasm(wasm: &[u8]) -> (Instance, Store<()>) {
+    let engine = Engine::default();
+    let module = wasmi::Module::new(&engine, wasm).expect("valid wasm module");
+    let mut store = Store::new(&engine, ());
+    let instance = Linker::<()>::new(&engine)
+        .instantiate(&mut store, &module)
+        .expect("instantiation")
+        .start(&mut store)
+        .expect("start");
+    (instance, store)
+}
+
+/// Compile + instantiate a source string, returning the live instance and
+/// store so a test can call exported functions.
+pub fn instantiate(source: &str) -> (Instance, Store<()>) {
+    instantiate_wasm(&compile(source))
+}
+
+/// Call an exported zero-argument function returning `i32`.
+pub fn call_i32(source: &str, func: &str) -> i32 {
+    let (instance, mut store) = instantiate(source);
+    instance
+        .get_typed_func::<(), i32>(&store, func)
+        .unwrap_or_else(|_| panic!("exported i32 fn `{func}`"))
+        .call(&mut store, ())
+        .expect("call")
+}
+
+/// Call an exported function taking two `i32` arguments and returning `i32`.
+pub fn call_i32_2(source: &str, func: &str, a: i32, b: i32) -> i32 {
+    let (instance, mut store) = instantiate(source);
+    instance
+        .get_typed_func::<(i32, i32), i32>(&store, func)
+        .unwrap_or_else(|_| panic!("exported i32 fn `{func}`"))
+        .call(&mut store, (a, b))
+        .expect("call")
+}


### PR DESCRIPTION
Add an integration test harness (tests/integration/, tests/utils/, registered as the `integration_examples` target) that compiles every examples/*.py, validates and instantiates the module with `wasmi`, and asserts runtime results. The sweep immediately surfaced two pre-existing codegen defects, both fixed here:

- String/bytes function parameters now form a complete (offset, length) pair: a parameter with no companion length local recovers the length from the blob prefix (`load(offset - 4)`), and a string argument to a user function is narrowed to the single offset word each parameter slot holds (the callee recovers the length). Fixes an invalid module and an out-of-bounds read.
- `raise ExceptionType(arg)` no longer strands the constructor argument on the stack: the exception resolves to its integer type code by name, shared with the `except` handler dispatch.

Also syncs README (Limitations, Features, Roadmap) and the docs/index.html site footer with shipped behavior, and bumps the version to 0.11.0.