### PR TITLE
docs(site): sync module board with the compiler and revamp landing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,8 @@ Do not consider a change complete until these pass cleanly.
 
 - **Update `CHANGELOG.md`** for any user-facing change (new feature, fix, breaking change).
 - **Update `README.md`** when supported features, limitations, or the public API change — the README's "Current Features" / "Limitations" lists are user-facing.
-- **Update `docs/` on every major change or feature update.** The `docs/` directory is the user-facing static HTML site (`index.html` landing page, `modules.html`, `changelog.html`, plus `assets/`). Whenever you add or change a feature, supported type, stdlib module, or any user-visible behaviour, reflect it in the relevant `docs/` page — keep `modules.html` in sync with what the compiler actually supports and `changelog.html` in sync with `CHANGELOG.md`. Don't let the published docs drift behind the code.
+- **Update `docs/` on every major change or feature update.** The `docs/` directory is the user-facing static HTML site (`index.html` landing page, `modules/index.html` development board, `changelog/index.html`, plus `assets/`). Whenever you add or change a feature, supported type, stdlib module, or any user-visible behaviour, reflect it in the relevant `docs/` page — keep the modules board in sync with what the compiler actually supports (the changelog page renders `CHANGELOG.md` from `main` automatically). Don't let the published docs drift behind the code.
+- **Version tags on the modules board name published releases only.** On `docs/modules/index.html`, a feature's `version` field is the release that shipped it. Work that is merged but not yet released is tagged `"upcoming"`, never a future or internal/planned version number. When a release ships, replace the `upcoming` tags of the features it contains with the actual release version.
 - **Prefer `just` commands** over raw `cargo` commands. The justfile handles sequencing, examples, and release steps correctly.
 - **Prompt the user if `AGENTS.md` needs updating.** If your changes alter the pipeline, module layout, public API, supported types/stdlib modules, or conventions, tell the user: *"This change may require an update to AGENTS.md — would you like me to update it?"*
 
@@ -308,6 +309,7 @@ test: description          # Adding/fixing tests
 - `just prepare-release` runs format → lint → build → test → `cargo publish --dry-run`.
 - `just publish` publishes to crates.io and then `just github-release` tags and creates the GitHub release.
 - Keep `CHANGELOG.md` updated with every meaningful change.
+- **On release, retag the docs modules board.** Replace every `"upcoming"` version tag in `docs/modules/index.html` for features shipping in the release with the new version number (see the housekeeping rule above; the board never names an unreleased version).
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,7 @@ Waspy follows Rust's standard coding conventions:
 3. **Documentation**
    - Add documentation comments to public APIs
    - Follow the [rustdoc conventions](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)
+   - If your change adds or completes a user-facing feature, update the development board (`docs/modules/index.html`). Tag the feature's version as `upcoming`; version tags on the board only ever name published releases, and maintainers swap `upcoming` for the real version number at release time
 
 4. **Commit Messages**
    - Write clear, concise commit messages
@@ -291,7 +292,10 @@ Releases are handled by the maintainers. The process is:
 1. **Version Bump**
    - Update version in `Cargo.toml`
 
-2. **Publish**
+2. **Docs Sync**
+   - In `docs/modules/index.html`, replace the `upcoming` version tags of features shipping in this release with the new version number. Features merged but not part of the release stay labeled `upcoming`; the board never shows a version that hasn't been published
+
+3. **Publish**
    - Run `just publish` to publish to crates.io and create a GitHub release
 
 ## Testing Generated WebAssembly

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,6 @@
                 <ul class="nav-links">
                     <li><a href="#how-it-works">How It Works</a></li>
                     <li><a href="#features">Features</a></li>
-                    <li><a href="#install">Install</a></li>
                     <li><a href="modules/">Modules</a></li>
                     <li><a href="changelog/">Changelog</a></li>
                     <li><a href="paper/">Paper</a></li>
@@ -73,68 +72,17 @@
                     Built in Rust for performance and reliability.
                 </p>
 
-                <div class="cta-buttons hero-seq">
-                    <a href="#install" class="btn btn-primary">
-                        🚀 Get Started
-                    </a>
-                    <a href="https://github.com/anistark/waspy" class="btn btn-secondary">
-                        📖 View Docs
-                    </a>
-                </div>
-
-                <div class="code-demo hero-seq">
-                    <div class="code-titlebar">
+                <div class="hero-terminal hero-seq">
+                    <div class="hero-terminal-titlebar">
                         <div class="window-dots"><span></span><span></span><span></span></div>
-                        <div class="code-tabs">
-                            <button class="code-tab active" data-tab="python">Python</button>
-                            <button class="code-tab" data-tab="rust">Rust</button>
-                            <button class="code-tab" data-tab="js">JavaScript</button>
-                        </div>
+                        <span class="hero-terminal-title">~/your-rust-project</span>
                     </div>
-
-                    <div class="code-content">
-                        <div class="code-panel active" id="python">
-                            <pre><code class="language-python"># fibonacci.py
-def fibonacci(n: int) -> int:
-    if n <= 1:
-        return n
-    a, b = 0, 1
-    for i in range(2, n + 1):
-        a, b = b, a + b
-    return b
-
-def factorial(n: int) -> int:
-    result = 1
-    for i in range(1, n + 1):
-        result *= i
-    return result</code></pre>
-                        </div>
-
-                        <div class="code-panel" id="rust">
-                            <pre><code class="language-rust">use waspy::compile_python_to_wasm;
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let python_code = std::fs::read_to_string("fibonacci.py")?;
-    let wasm = compile_python_to_wasm(&python_code)?;
-    std::fs::write("fibonacci.wasm", &wasm)?;
-    println!("✅ Compiled to WebAssembly!");
-    Ok(())
-}</code></pre>
-                        </div>
-
-                        <div class="code-panel" id="js">
-                            <pre><code class="language-javascript">// Run the compiled WebAssembly
-WebAssembly.instantiate(wasmBuffer).then(result => {
-    const { fibonacci, factorial } = result.instance.exports;
-
-    console.log(fibonacci(10)); // 55
-    console.log(factorial(5));  // 120
-
-    // Blazing fast execution! 🔥
-});</code></pre>
-                        </div>
+                    <div class="hero-terminal-body">
+                        <code><span class="prompt">$</span> cargo add waspy</code>
+                        <button class="copy-btn" data-copy="cargo add waspy">Copy</button>
                     </div>
                 </div>
+                <p class="hero-terminal-note hero-seq">Waspy is a Rust library. Add it to your project and compile Python to WebAssembly.</p>
             </div>
         </section>
 
@@ -171,8 +119,117 @@ WebAssembly.instantiate(wasmBuffer).then(result => {
                         <p>Binaryen</p>
                     </div>
                 </div>
+            </div>
 
-                <div class="comparison glass reveal">
+            <div class="container container--wide">
+                <div class="section-header reveal">
+                    <h2 style="font-size: 1.75rem;">The Same Pipeline, In Code</h2>
+                    <p class="section-subtitle">Write Python, compile it from Rust, run it from JavaScript or TypeScript.</p>
+                </div>
+
+                <div class="example-flow">
+                    <div class="example-step reveal" style="--d: 0;">
+                        <div class="example-window">
+                            <div class="example-titlebar">
+                                <div class="window-dots"><span></span><span></span><span></span></div>
+                                <span class="example-filename">fibonacci.py</span>
+                            </div>
+                            <pre><code class="language-python">def fibonacci(n: int) -&gt; int:
+    if n &lt;= 1:
+        return n
+    a, b = 0, 1
+    for i in range(2, n + 1):
+        a, b = b, a + b
+    return b
+
+def factorial(n: int) -&gt; int:
+    result = 1
+    for i in range(1, n + 1):
+        result *= i
+    return result</code></pre>
+                        </div>
+                        <div class="example-caption">
+                            <span class="example-badge">1 · Write Python</span>
+                            Ordinary, type-annotated Python is the compiler's input. Annotations pick the WASM value types:
+                            <span class="cmd">int</span>/<span class="cmd">bool</span> become <span class="cmd">i32</span>, <span class="cmd">float</span> becomes <span class="cmd">f64</span>.
+                        </div>
+                    </div>
+
+                    <span class="example-arrow reveal" style="--d: 1;">→</span>
+
+                    <div class="example-step reveal" style="--d: 2;">
+                        <div class="example-window">
+                            <div class="example-titlebar">
+                                <div class="window-dots"><span></span><span></span><span></span></div>
+                                <span class="example-filename">main.rs</span>
+                            </div>
+                            <pre><code class="language-rust">// in your Rust project,
+// after `cargo add waspy`
+use waspy::compile_python_file;
+
+fn main() -&gt; Result&lt;(), Box&lt;dyn std::error::Error&gt;&gt; {
+    // parse → typed IR → codegen → Binaryen
+    let wasm =
+        compile_python_file("fibonacci.py", true)?;
+
+    // a standalone module,
+    // no Python interpreter inside
+    std::fs::write("fibonacci.wasm", &amp;wasm)?;
+    Ok(())
+}</code></pre>
+                        </div>
+                        <div class="example-caption">
+                            <span class="example-badge">2 · Compile from Rust</span>
+                            <span class="cmd">cargo run</span> turns fibonacci.py into <span class="cmd">fibonacci.wasm</span>.
+                            Every top-level Python function becomes a WASM export; imports of sibling .py files link in automatically.
+                        </div>
+                    </div>
+
+                    <span class="example-arrow reveal" style="--d: 3;">→</span>
+
+                    <div class="example-step reveal" style="--d: 4;">
+                        <div class="example-window">
+                            <div class="example-titlebar">
+                                <div class="window-dots"><span></span><span></span><span></span></div>
+                                <span class="example-filename">run.mjs</span>
+                            </div>
+                            <pre><code class="language-javascript">// Node 18+
+// (TypeScript works the same)
+import { readFile } from "node:fs/promises";
+
+const wasm = await readFile("./fibonacci.wasm");
+const { instance } =
+    await WebAssembly.instantiate(wasm);
+
+console.log(instance.exports.fibonacci(10));
+// 55
+console.log(instance.exports.factorial(5));
+// 120</code></pre>
+                        </div>
+                        <div class="example-caption">
+                            <span class="example-badge">3 · Run from JS/TS</span>
+                            <span class="cmd">node run.mjs</span> prints <span class="cmd">55</span> and <span class="cmd">120</span>: your Python, running as WebAssembly.
+                            In a browser, swap <span class="cmd">readFile</span> for <span class="cmd">fetch</span> + <span class="cmd">WebAssembly.instantiateStreaming</span>.
+                        </div>
+                    </div>
+                </div>
+
+                <div class="example-alt reveal">
+                    <div class="example-alt-card">
+                        <span class="example-badge">From a source string</span>
+                        <code>let wasm = waspy::compile_python_to_wasm(&amp;source)?;</code>
+                        <p>Compile Python you already hold in memory, no files involved.</p>
+                    </div>
+                    <div class="example-alt-card">
+                        <span class="example-badge">From a project directory</span>
+                        <code>let wasm = waspy::compile_python_project("./my_project", true)?;</code>
+                        <p>Compile a project directory into one module, with __main__.py entry detection and pyproject.toml config.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="container">
+                <div class="comparison reveal">
                     <div class="section-header">
                         <h2 style="font-size: 1.75rem;">Waspy vs Other Python Implementations</h2>
                         <p class="section-subtitle">See how Waspy compares across performance, safety, and portability.</p>
@@ -286,7 +343,7 @@ WebAssembly.instantiate(wasmBuffer).then(result => {
                         <div class="hex-cell reveal" data-accent="amber" style="--d: 0;">
                             <div class="hex-card">
                                 <h3>Ahead-of-Time Compilation</h3>
-                                <p>Python compiles to a WASM binary before it runs — no interpreter or VM in the output.</p>
+                                <p>Python compiles to a WASM binary before it runs, with no interpreter or VM in the output.</p>
                                 <span class="feature-tag">no runtime VM</span>
                             </div>
                         </div>
@@ -339,7 +396,7 @@ WebAssembly.instantiate(wasmBuffer).then(result => {
                         <div class="hex-cell reveal" data-accent="red" style="--d: 2;">
                             <div class="hex-card">
                                 <h3>Import Analysis</h3>
-                                <p>User-written .py modules resolve from disk and link statically — each compiled once, with namespace calls and aliases.</p>
+                                <p>User-written .py modules resolve from disk and link statically, each compiled once, with namespace calls and aliases.</p>
                                 <span class="feature-tag">user modules</span>
                             </div>
                         </div>
@@ -414,7 +471,7 @@ WebAssembly.instantiate(wasmBuffer).then(result => {
                         <text x="455" y="510" fill="#ec6a3f" font-size="11" font-family="JetBrains Mono, monospace" opacity="0.85">Combine All IRModules</text>
                         <text x="455" y="755" fill="#a89478" font-size="11" font-family="Instrument Sans, sans-serif" opacity="0.85">Same as Single File from here</text>
 
-                        <g class="flow-node" data-step="1" data-info="The entry point — your Python project directory containing source files and configuration.">
+                        <g class="flow-node" data-step="1" data-info="The entry point: your Python project directory containing source files and configuration.">
                             <rect x="285" y="20" width="330" height="55" rx="27" ry="27" fill="transparent" stroke="#f2a83b" stroke-width="2" filter="url(#glow-amber)"/>
                             <text x="450" y="54" fill="#ffd28a" font-size="18" font-weight="600" font-family="Instrument Sans, sans-serif" text-anchor="middle">📁 Project Directory</text>
                         </g>
@@ -485,53 +542,6 @@ WebAssembly.instantiate(wasmBuffer).then(result => {
             </div>
         </section>
 
-        <section class="section" id="install">
-            <div class="container">
-                <div class="section-header reveal">
-                    <span class="kicker">Install</span>
-                    <h2>Get Started in Minutes</h2>
-                    <p class="section-subtitle">Four steps from zero to compiled WebAssembly.</p>
-                </div>
-
-                <div class="install-steps">
-                    <div class="install-step reveal" data-step="1" style="--d: 0;">
-                        <h3>Install Waspy</h3>
-                        <p>Add Waspy to your Rust project:</p>
-                        <div class="install-command">
-                            <code>cargo add waspy</code>
-                            <button class="copy-btn" data-copy="cargo add waspy">Copy</button>
-                        </div>
-                    </div>
-
-                    <div class="install-step reveal" data-step="2" style="--d: 1;">
-                        <h3>Compile Python to WASM</h3>
-                        <p>Use the simple API to compile your Python functions:</p>
-                        <div class="install-command">
-                            <code>let wasm = waspy::compile_python_to_wasm(python_code)?;</code>
-                            <button class="copy-btn" data-copy="let wasm = waspy::compile_python_to_wasm(python_code)?;">Copy</button>
-                        </div>
-                    </div>
-
-                    <div class="install-step reveal" data-step="3" style="--d: 2;">
-                        <h3>Advanced Features</h3>
-                        <p>Compile entire projects with options:</p>
-                        <div class="install-command">
-                            <code>let wasm = waspy::compile_python_project("./my_project", true)?;</code>
-                            <button class="copy-btn" data-copy='let wasm = waspy::compile_python_project("./my_project", true)?;'>Copy</button>
-                        </div>
-                    </div>
-
-                    <div class="install-step reveal" data-step="4" style="--d: 3;">
-                        <h3>Run Anywhere</h3>
-                        <p>Execute your compiled WebAssembly in any environment:</p>
-                        <div class="install-command">
-                            <code>WebAssembly.instantiate(wasm).then(instance => { /* magic */ });</code>
-                            <button class="copy-btn" data-copy="WebAssembly.instantiate(wasm).then(instance => { /* magic */ });">Copy</button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
     </main>
 
     <footer class="site-footer">
@@ -602,15 +612,6 @@ WebAssembly.instantiate(wasmBuffer).then(result => {
     <script src="main.js"></script>
 
     <script>
-        document.querySelectorAll('.code-tab').forEach(tab => {
-            tab.addEventListener('click', () => {
-                document.querySelectorAll('.code-tab').forEach(t => t.classList.remove('active'));
-                document.querySelectorAll('.code-panel').forEach(p => p.classList.remove('active'));
-                tab.classList.add('active');
-                document.getElementById(tab.dataset.tab).classList.add('active');
-            });
-        });
-
         (function () {
             const tooltip = document.getElementById('flowTooltip');
             const svg = document.getElementById('flowchartSvg');
@@ -631,7 +632,7 @@ WebAssembly.instantiate(wasmBuffer).then(result => {
             function showTooltip(node, e) {
                 const step = node.getAttribute('data-step');
                 const info = node.getAttribute('data-info');
-                tooltip.innerHTML = '<div class="step-label">Step ' + step + ' — ' + (stepNames[step] || '') + '</div>' + info;
+                tooltip.innerHTML = '<div class="step-label">Step ' + step + ': ' + (stepNames[step] || '') + '</div>' + info;
                 tooltip.style.display = 'block';
                 positionTooltip(e);
             }

--- a/docs/modules/index.html
+++ b/docs/modules/index.html
@@ -151,7 +151,7 @@
             },
             controlFlow: {
                 title: "CONTROL FLOW",
-                status: "done",
+                status: "progress",
                 version: "0.1.0",
                 features: [
                     { name: "if/elif/else statements", status: "done", version: "0.1.0" },
@@ -159,7 +159,7 @@
                     { name: "for loops with list/string iteration", status: "done", version: "0.7.0" },
                     { name: "break and continue in loops", status: "done", version: "0.11.0" },
                     { name: "try/except/finally exception handling", status: "done", version: "0.7.0" },
-                    { name: "with statements (with open(...) as f; custom context managers pending #5)", status: "progress", version: "0.19.0" },
+                    { name: "with statements (with open(...) as f; custom context managers pending)", status: "progress", version: "upcoming", issue: 5 },
                     { name: "Comparison operations (==, !=, <, <=, >, >=)", status: "done", version: "0.1.0" },
                     { name: "Boolean logic (and, or, not) with short-circuit", status: "done", version: "0.1.0" }
                 ]
@@ -225,10 +225,10 @@
                 version: "0.1.0",
                 features: [
                     { name: "WebAssembly optimization (Binaryen)", status: "done", version: "0.1.0" },
-                    { name: "Compiler options & configuration (reviewed API: optimize + verbosity)", status: "done", version: "0.20.0" },
-                    { name: "Error handling with located messages (line/column, function, hints)", status: "done", version: "0.20.0" },
-                    { name: "Early validation - unsupported syntax rejected before codegen", status: "done", version: "0.20.0" },
-                    { name: "Integration test suite - every example compiled, run, and asserted in CI", status: "done", version: "0.20.0" },
+                    { name: "Compiler options & configuration (reviewed API: optimize + verbosity)", status: "done", version: "upcoming" },
+                    { name: "Error handling with located messages (line/column, function, hints)", status: "done", version: "upcoming" },
+                    { name: "Early validation - unsupported syntax rejected before codegen", status: "done", version: "upcoming" },
+                    { name: "Integration test suite - every example compiled, run, and asserted in CI", status: "done", version: "upcoming" },
                     { name: "Memory layout optimization", status: "done", version: "0.1.0" }
                 ]
             },
@@ -273,25 +273,13 @@
                     { name: "Instance attribute access getter (obj.attr)", status: "done", version: "0.7.0" },
                     { name: "Instance attribute assignment setter (obj.attr = value)", status: "done", version: "0.7.0" },
                     { name: "Per-instance field storage with calculated memory offsets", status: "done", version: "0.7.0" },
-                    { name: "Heap-allocated instances — a distinct pointer per instantiation", status: "done", version: "0.13.0" },
-                    { name: "Multiple live instances of one class with independent state", status: "done", version: "0.13.0" },
-                    { name: "Instances as first-class values (arguments, factory returns)", status: "done", version: "0.13.0" },
-                    { name: "Single inheritance with super().__init__ / super().method()", status: "done", version: "0.14.0" },
-                    { name: "isinstance / issubclass over the class hierarchy", status: "done", version: "0.14.0" },
-                    { name: "@dataclass with generated __init__ / __eq__ / __repr__", status: "done", version: "0.16.0" },
-                    { name: "Abstract base classes (abc.ABC + @abstractmethod)", status: "done", version: "0.16.0" }
-                ]
-            },
-            advancedFlow: {
-                title: "ADVANCED CONTROL FLOW",
-                status: "done",
-                version: "0.7.0",
-                features: [
-                    { name: "for loops with list/string iteration", status: "done", version: "0.7.0" },
-                    { name: "break and continue (with correct nesting in if/try/loops)", status: "done", version: "0.11.0" },
-                    { name: "try/except/finally with exception handling", status: "done", version: "0.7.0" },
-                    { name: "with statements (with open(...) as f; custom context managers pending #5)", status: "progress", version: "0.19.0" },
-                    { name: "Exception type matching and handlers", status: "done", version: "0.7.0" }
+                    { name: "Heap-allocated instances: a distinct pointer per instantiation", status: "done", version: "0.12.0" },
+                    { name: "Multiple live instances of one class with independent state", status: "done", version: "0.12.0" },
+                    { name: "Instances as first-class values (arguments, factory returns)", status: "done", version: "0.12.0" },
+                    { name: "Single inheritance with super().__init__ / super().method()", status: "done", version: "0.12.0" },
+                    { name: "isinstance / issubclass over the class hierarchy", status: "done", version: "0.12.0" },
+                    { name: "@dataclass with generated __init__ / __eq__ / __repr__", status: "done", version: "0.12.0" },
+                    { name: "Abstract base classes (abc.ABC + @abstractmethod)", status: "done", version: "0.12.0" }
                 ]
             },
             builtins: {
@@ -303,7 +291,7 @@
                     { name: "len() - strings, lists, and dicts", status: "done", version: "0.7.0" },
                     { name: "print() - argument handling implemented", status: "done", version: "0.7.0" },
                     { name: "min() & max() - multiple arguments (single-iterable form rejected with a hint)", status: "done", version: "0.7.0" },
-                    { name: "sum() over lists/tuples with optional start value - real element loop", status: "done", version: "0.20.0" }
+                    { name: "sum() over lists/tuples with optional start value - real element loop", status: "done", version: "upcoming" }
                 ]
             },
             runtimeFeatures: {
@@ -313,9 +301,9 @@
                 features: [
                     { name: "Set storage with de-duplication & membership (in / not in)", status: "done" },
                     { name: "Dict index assignment with update or append (dict[key] = value)", status: "done" },
-                    { name: "Generator State Management - execution context suspension/resumption", status: "done", version: "0.18.0" },
-                    { name: "Dynamic Module Loading - runtime module loading and execution", status: "progress" },
-                    { name: "Closure Variable Capture Analysis - detecting and capturing closure variables", status: "done", version: "0.17.0" },
+                    { name: "Generator State Management - execution context suspension/resumption", status: "done", version: "upcoming" },
+                    { name: "Dynamic Module Loading - runtime module loading and execution", status: "todo" },
+                    { name: "Closure Variable Capture Analysis - detecting and capturing closure variables", status: "done", version: "upcoming" },
                     { name: "String Transformation in WASM - full character-by-char transformations", status: "progress" }
                 ]
             },
@@ -326,7 +314,7 @@
                     { name: "JavaScript bridge & value conversion", status: "todo" },
                     { name: "DOM manipulation APIs", status: "todo" },
                     { name: "Event handling system", status: "todo" },
-                    { name: "HTTP requests (fetch API)", status: "todo" }
+                    { name: "HTTP requests (fetch API)", status: "todo", issue: 35 }
                 ]
             },
             async: {
@@ -334,7 +322,7 @@
                 status: "todo",
                 features: [
                     { name: "Promise object representation", status: "todo" },
-                    { name: "async/await syntax support", status: "todo" },
+                    { name: "async/await syntax support", status: "todo", issue: 7 },
                     { name: "Asynchronous function execution", status: "todo" },
                     { name: "Concurrent task management", status: "todo" }
                 ]
@@ -362,14 +350,14 @@
             comprehensions: {
                 title: "COMPREHENSIONS",
                 status: "done",
-                version: "0.17.0",
+                version: "upcoming",
                 features: [
-                    { name: "List comprehensions ([x for x in list])", status: "done", version: "0.17.0" },
-                    { name: "List comprehension filters ([x for x in list if condition])", status: "done", version: "0.17.0" },
-                    { name: "Dict comprehensions ({k: v for k, v in items})", status: "done", version: "0.17.0" },
-                    { name: "Set comprehensions ({x for x in list}) with dedup at construction", status: "done", version: "0.17.0" },
-                    { name: "Multiple generators & nesting ([x for row in m for x in row])", status: "done", version: "0.17.0" },
-                    { name: "Generator expressions (x for x in list) — materialized eagerly as lists", status: "done", version: "0.17.0" }
+                    { name: "List comprehensions ([x for x in list])", status: "done", version: "upcoming" },
+                    { name: "List comprehension filters ([x for x in list if condition])", status: "done", version: "upcoming" },
+                    { name: "Dict comprehensions ({k: v for k, v in items})", status: "done", version: "upcoming" },
+                    { name: "Set comprehensions ({x for x in list}) with dedup at construction", status: "done", version: "upcoming" },
+                    { name: "Multiple generators & nesting ([x for row in m for x in row])", status: "done", version: "upcoming" },
+                    { name: "Generator expressions (x for x in list), materialized eagerly as lists", status: "done", version: "upcoming" }
                 ]
             },
             functional: {
@@ -377,27 +365,27 @@
                 status: "done",
                 version: "0.8.0",
                 features: [
-                    { name: "Lambda functions (lambda x: x + 1) compiled to real functions", status: "done", version: "0.17.0" },
-                    { name: "Closures with variable capture (by value at creation)", status: "done", version: "0.17.0" },
-                    { name: "First-class closures — returned, passed as arguments, stored in collections, nested", status: "done", version: "0.17.0" },
-                    { name: "Higher-order functions (passing functions as arguments)", status: "done", version: "0.17.0" },
+                    { name: "Lambda functions (lambda x: x + 1) compiled to real functions", status: "done", version: "upcoming" },
+                    { name: "Closures with variable capture (by value at creation)", status: "done", version: "upcoming" },
+                    { name: "First-class closures: returned, passed as arguments, stored in collections, nested", status: "done", version: "upcoming" },
+                    { name: "Higher-order functions (passing functions as arguments)", status: "done", version: "upcoming" },
                     { name: "Callable type tracking for function objects", status: "done", version: "0.8.0" }
                 ]
             },
             generators: {
                 title: "GENERATORS & ITERATORS",
                 status: "done",
-                version: "0.18.0",
+                version: "upcoming",
                 features: [
-                    { name: "Generator functions - yield suspends and resumes with state preserved", status: "done", version: "0.18.0" },
-                    { name: "yield from delegation (ranges, lists, other generators)", status: "done", version: "0.18.0" },
-                    { name: "next(), send() with x = yield resume values, and close()", status: "done", version: "0.18.0" },
-                    { name: "Iterator protocol (__iter__, __next__) on user classes with StopIteration", status: "done", version: "0.18.0" },
+                    { name: "Generator functions - yield suspends and resumes with state preserved", status: "done", version: "upcoming" },
+                    { name: "yield from delegation (ranges, lists, other generators)", status: "done", version: "upcoming" },
+                    { name: "next(), send() with x = yield resume values, and close()", status: "done", version: "upcoming" },
+                    { name: "Iterator protocol (__iter__, __next__) on user classes with StopIteration", status: "done", version: "upcoming" },
                     { name: "Generator type tracking (Generator[T])", status: "done", version: "0.8.0" },
                     { name: "range() function implementation - all variants", status: "done", version: "0.8.0" },
                     { name: "for loop iteration over ranges with step support", status: "done", version: "0.8.0" },
-                    { name: "Tuple targets in for loops (for a, b in pairs, star targets)", status: "done", version: "0.18.0" },
-                    { name: "enumerate(), zip(), and dict.items()/.keys()/.values() in for loops", status: "done", version: "0.18.0" }
+                    { name: "Tuple targets in for loops (for a, b in pairs, star targets)", status: "done", version: "upcoming" },
+                    { name: "enumerate(), zip(), and dict.items()/.keys()/.values() in for loops", status: "done", version: "upcoming" }
                 ]
             },
             imports: {
@@ -411,21 +399,21 @@
                     { name: "Conditional imports in try/except blocks", status: "done", version: "0.8.0" },
                     { name: "Dynamic imports (__import__, importlib)", status: "done", version: "0.8.0" },
                     { name: "Module execution and loading", status: "done", version: "0.8.0" },
-                    { name: "User-defined module files - import mod / from mod import f resolved from sibling .py files and statically linked", status: "done", version: "0.19.0" },
-                    { name: "Namespace access on user modules (mod.f(), mod.CONST, mod.ClassName()) and aliases (import mod as m, from mod import f as g)", status: "done", version: "0.19.0" },
-                    { name: "Module caching - a module imported through several paths compiles once", status: "done", version: "0.19.0" }
+                    { name: "User-defined module files - import mod / from mod import f resolved from sibling .py files and statically linked", status: "done", version: "upcoming" },
+                    { name: "Namespace access on user modules (mod.f(), mod.CONST, mod.ClassName()) and aliases (import mod as m, from mod import f as g)", status: "done", version: "upcoming" },
+                    { name: "Module caching - a module imported through several paths compiles once", status: "done", version: "upcoming" }
                 ]
             },
             fileIo: {
                 title: "FILE I/O",
                 status: "done",
-                version: "0.19.0",
+                version: "upcoming",
                 features: [
-                    { name: "open(path, mode) via the documented waspy_host import interface (r, w, a, b, + modes folded to flags)", status: "done", version: "0.19.0" },
-                    { name: "read() / read(n) returning strings (64 KiB default cap per call)", status: "done", version: "0.19.0" },
-                    { name: "write(s) returning bytes written; close() and flush()", status: "done", version: "0.19.0" },
-                    { name: "with open(...) as f: context-manager form (desugared to open/body/close)", status: "done", version: "0.19.0" },
-                    { name: "Import section emitted only when open() is used - other modules keep zero imports", status: "done", version: "0.19.0" }
+                    { name: "open(path, mode) via the documented waspy_host import interface (r, w, a, b, + modes folded to flags)", status: "done", version: "upcoming" },
+                    { name: "read() / read(n) returning strings (64 KiB default cap per call)", status: "done", version: "upcoming" },
+                    { name: "write(s) returning bytes written; close() and flush()", status: "done", version: "upcoming" },
+                    { name: "with open(...) as f: context-manager form (desugared to open/body/close)", status: "done", version: "upcoming" },
+                    { name: "Import section emitted only when open() is used - other modules keep zero imports", status: "done", version: "upcoming" }
                 ]
             },
             errorHandling: {
@@ -441,7 +429,7 @@
             },
             advancedTypes: {
                 title: "ADVANCED DATA TYPES",
-                status: "done",
+                status: "progress",
                 version: "0.8.0",
                 features: [
                     { name: "Bytes type & binary data handling", status: "done", version: "0.7.0" },
@@ -453,7 +441,7 @@
                     { name: "Tuple indexing with type tracking", status: "done", version: "0.8.0" },
                     { name: "Heterogeneous tuples with mixed types", status: "done", version: "0.8.0" },
                     { name: "Tuple unpacking & assignment (a, b = (1, 2))", status: "done", version: "0.8.0" },
-                    { name: "Extended (starred) unpacking (a, *b, c = xs)", status: "done", version: "0.17.0" },
+                    { name: "Extended (starred) unpacking (a, *b, c = xs)", status: "done", version: "upcoming" },
                     { name: "Tuple methods (.index, .count)", status: "done", version: "0.8.0" },
                     { name: "Named tuples - namedtuple() factory", status: "done", version: "0.8.0" },
                     { name: "String formatting (.format() & % & f-strings)", status: "done" }
@@ -463,10 +451,10 @@
                 title: "ADVANCED OOP",
                 status: "progress",
                 features: [
-                    { name: "Property decorators (@property, @<name>.setter)", status: "done", version: "0.15.0" },
-                    { name: "Static & class methods (@staticmethod, @classmethod with cls factories)", status: "done", version: "0.15.0" },
+                    { name: "Property decorators (@property, @<name>.setter)", status: "done", version: "0.12.0" },
+                    { name: "Static & class methods (@staticmethod, @classmethod with cls factories)", status: "done", version: "0.12.0" },
                     { name: "Multiple inheritance & method resolution", status: "todo" },
-                    { name: "Metaclasses & class creation", status: "todo" }
+                    { name: "Metaclasses & class creation", status: "todo", issue: 8 }
                 ]
             },
             memory: {
@@ -682,32 +670,42 @@
             return Math.round(((completed + partial) / total) * 100);
         }
 
+        function createIssueLink(issue) {
+            return `
+                <a class="feature-issue" href="https://github.com/anistark/waspy/issues/${issue}" target="_blank" rel="noopener" title="Open issue #${issue} on GitHub" aria-label="Open issue #${issue} on GitHub">
+                    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/>
+                        <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/>
+                    </svg>
+                </a>
+            `;
+        }
+
         function createModuleCard(moduleKey, module) {
             const progress = calculateModuleProgress(module);
 
             return `
                 <div class="module-card ${module.status}" data-module="${moduleKey}">
-                    <div class="card-header">
+                    <div class="card-header" role="button" tabindex="0" aria-expanded="false" title="${module.features.length} items. Click to expand">
                         <span class="card-title">${module.title}</span>
                         <span class="card-status">${getStatusLabel(module.status)}</span>
+                        <span class="card-chevron" aria-hidden="true">▾</span>
                     </div>
-                    <ul class="feature-list">
-                        ${module.features.map(feature => `
-                            <li class="feature-item">
-                                <span class="feature-status">${getStatusIcon(feature.status)}</span>
-                                <span class="feature-text">${feature.name}</span>
-                                ${feature.version && feature.version !== 'todo' ? `<span class="feature-version" title="Version introduced">${feature.version}</span>` : ''}
-                            </li>
-                        `).join('')}
-                    </ul>
-                    ${module.status !== 'done' ? `
-                        <div class="progress-indicator">
-                            <div class="progress-bar">
-                                <div class="progress-fill" style="width: 0%" data-width="${progress}%"></div>
-                            </div>
-                            <div class="progress-text">${progress}% Complete</div>
-                        </div>
-                    ` : ''}
+                    <div class="progress-bar" title="${progress}% complete" aria-label="${progress}% complete">
+                        <div class="progress-fill" style="width: 0%" data-width="${progress}%"></div>
+                    </div>
+                    <div class="card-body">
+                        <ul class="feature-list">
+                            ${module.features.map(feature => `
+                                <li class="feature-item">
+                                    <span class="feature-status">${getStatusIcon(feature.status)}</span>
+                                    <span class="feature-text">${feature.name}</span>
+                                    ${feature.issue ? createIssueLink(feature.issue) : ''}
+                                    ${feature.version && feature.version !== 'todo' ? `<span class="feature-version${feature.version === 'upcoming' ? ' upcoming' : ''}" title="${feature.version === 'upcoming' ? 'Merged, ships in the next release' : 'Version introduced'}">${feature.version}</span>` : ''}
+                                </li>
+                            `).join('')}
+                        </ul>
+                    </div>
                 </div>
             `;
         }
@@ -737,6 +735,21 @@
                         todoColumn.innerHTML += card;
                         break;
                 }
+            });
+
+            document.querySelectorAll('.module-card .card-header').forEach(header => {
+                const toggle = () => {
+                    const card = header.closest('.module-card');
+                    const expanded = card.classList.toggle('expanded');
+                    header.setAttribute('aria-expanded', expanded);
+                };
+                header.addEventListener('click', toggle);
+                header.addEventListener('keydown', event => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        toggle();
+                    }
+                });
             });
 
             setTimeout(() => {

--- a/docs/style.css
+++ b/docs/style.css
@@ -585,6 +585,91 @@ body::after {
     to { opacity: 1; transform: translateY(0); }
 }
 
+/* Install terminal in the hero */
+.hero-terminal {
+    max-width: 520px;
+    margin: 2.4rem auto 0;
+    background: var(--bg-glass-strong);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    border: 1px solid color-mix(in srgb, var(--amber) 38%, var(--glass-border));
+    border-radius: var(--radius);
+    box-shadow:
+        inset 0 1px 0 var(--glass-highlight),
+        var(--shadow-deep),
+        0 0 48px color-mix(in srgb, var(--amber) 16%, transparent);
+    overflow: hidden;
+    text-align: left;
+}
+
+.hero-terminal-titlebar {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.65rem 1.1rem;
+    border-bottom: 1px solid var(--glass-border);
+}
+
+.hero-terminal-titlebar .window-dots {
+    padding-bottom: 0;
+}
+
+.hero-terminal-title {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    color: var(--text-2);
+}
+
+.hero-terminal-body {
+    position: relative;
+    padding: 1.15rem 5.5rem 1.15rem 1.25rem;
+}
+
+.hero-terminal-body code {
+    font-size: 1.02rem;
+    font-weight: 500;
+    color: var(--text-0);
+}
+
+.hero-terminal-body .prompt {
+    color: var(--green);
+    margin-right: 0.4rem;
+    user-select: none;
+}
+
+.hero-terminal-body .copy-btn {
+    top: 50%;
+    transform: translateY(-50%);
+    right: 0.85rem;
+}
+
+.hero-terminal-note {
+    margin-top: 1.1rem;
+    color: var(--text-2);
+    font-size: 0.9rem;
+}
+
+/* Explanation under each code panel */
+.code-caption {
+    margin-top: 1.1rem;
+    padding-top: 0.9rem;
+    border-top: 1px dashed var(--glass-border);
+    color: var(--text-1);
+    font-size: 0.84rem;
+    line-height: 1.65;
+}
+
+.code-caption strong {
+    color: var(--text-0);
+}
+
+.code-caption .cmd,
+.example-caption .cmd {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--honey);
+}
+
 pre {
     margin: 0;
     background: transparent !important;
@@ -600,6 +685,7 @@ code {
 
 /* Prism token warmth on light theme (tomorrow theme is tuned for dark) */
 [data-theme="light"] .code-demo code[class*="language-"],
+[data-theme="light"] .example-window code[class*="language-"],
 [data-theme="light"] .markdown-content pre code {
     color: #433017;
     text-shadow: none;
@@ -737,10 +823,155 @@ code {
     opacity: 0.7;
 }
 
+/* Example walkthrough — the pipeline, shown as code */
+.example-flow {
+    display: flex;
+    align-items: stretch;
+    justify-content: center;
+    gap: 1rem;
+    margin: 2.5rem 0 1.25rem;
+}
+
+.example-step {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.example-arrow {
+    font-size: 1.5rem;
+    color: var(--amber);
+    flex-shrink: 0;
+    align-self: center;
+    opacity: 0.7;
+}
+
+.example-window {
+    flex: 1;
+    background: var(--bg-glass-strong);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius);
+    box-shadow: inset 0 1px 0 var(--glass-highlight), var(--shadow-soft);
+    overflow: hidden;
+    text-align: left;
+}
+
+.example-titlebar {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.75rem 1.1rem 0;
+}
+
+.example-titlebar .window-dots {
+    padding-bottom: 0;
+}
+
+.example-filename {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text-2);
+}
+
+.example-window pre {
+    padding: 0.9rem 1.2rem 1.2rem;
+}
+
+.example-window code {
+    font-size: 0.75rem;
+    line-height: 1.7;
+}
+
+.example-caption {
+    margin-top: 0.9rem;
+    padding: 0 0.35rem;
+    color: var(--text-1);
+    font-size: 0.84rem;
+    line-height: 1.6;
+    text-align: left;
+}
+
+.example-badge {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--amber);
+    margin-bottom: 0.3rem;
+}
+
+/* Alternate compile entry points, below the walkthrough */
+.example-alt {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin: 0 0 3.5rem;
+}
+
+.example-alt-card {
+    flex: 1;
+    max-width: 560px;
+    min-width: 0;
+    background: var(--bg-glass);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius);
+    padding: 1.1rem 1.25rem;
+    text-align: left;
+}
+
+.example-alt-card > code {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-0);
+    white-space: nowrap;
+    overflow-x: auto;
+    margin-bottom: 0.5rem;
+}
+
+.example-alt-card p {
+    color: var(--text-1);
+    font-size: 0.84rem;
+    line-height: 1.6;
+    margin: 0;
+}
+
+@media (max-width: 1200px) {
+    .example-flow {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.75rem;
+    }
+
+    .example-arrow {
+        transform: rotate(90deg);
+    }
+
+    .example-step {
+        max-width: 640px;
+        width: 100%;
+        margin: 0 auto;
+    }
+
+    .example-alt {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .example-alt-card {
+        width: 100%;
+        max-width: 640px;
+    }
+}
+
 /* Comparison table */
 .comparison {
-    padding: 2.5rem;
-    margin: 2rem 0;
+    padding: 0;
+    margin: 3rem 0 2rem;
 }
 
 .comparison-table {
@@ -1529,9 +1760,15 @@ a.footer-link:hover {
     align-items: center;
     justify-content: space-between;
     gap: 0.75rem;
-    margin-bottom: 1rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid var(--glass-border);
+    margin-bottom: 0.85rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.card-header:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--status-accent) 60%, transparent);
+    outline-offset: 4px;
+    border-radius: var(--radius-sm);
 }
 
 .card-title {
@@ -1539,6 +1776,20 @@ a.footer-link:hover {
     font-size: 1rem;
     font-weight: 700;
     letter-spacing: 0.02em;
+    margin-right: auto;
+}
+
+.card-chevron {
+    color: var(--text-2);
+    font-size: 0.8rem;
+    line-height: 1;
+    transform: rotate(-90deg);
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.module-card.expanded .card-chevron {
+    transform: rotate(0deg);
+    color: var(--status-accent);
 }
 
 .card-status {
@@ -1555,8 +1806,24 @@ a.footer-link:hover {
     white-space: nowrap;
 }
 
+.card-body {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.4s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.module-card.expanded .card-body {
+    grid-template-rows: 1fr;
+}
+
+.card-body > .feature-list {
+    overflow: hidden;
+    min-height: 0;
+}
+
 .feature-list {
     list-style: none;
+    padding-top: 0.35rem;
 }
 
 .feature-item {
@@ -1597,18 +1864,18 @@ a.footer-link:hover {
     align-self: center;
 }
 
-.progress-indicator {
-    margin-top: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--glass-border);
+.feature-version.upcoming {
+    background: color-mix(in srgb, var(--amber) 14%, transparent);
+    color: var(--amber);
+    border-color: color-mix(in srgb, var(--amber) 30%, transparent);
 }
 
+/* Divider under the card title, doubling as a subtle progress indicator */
 .progress-bar {
-    background: color-mix(in srgb, var(--status-accent) 12%, transparent);
+    background: color-mix(in srgb, var(--glass-border) 70%, transparent);
     border-radius: 10px;
-    height: 8px;
+    height: 3px;
     overflow: hidden;
-    margin-bottom: 0.5rem;
 }
 
 .progress-fill {
@@ -1618,12 +1885,25 @@ a.footer-link:hover {
     transition: width 1s cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
-.progress-text {
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
+.feature-issue {
+    display: inline-flex;
+    align-items: center;
+    align-self: center;
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
     color: var(--text-2);
-    text-align: center;
-    font-weight: 600;
+    transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.feature-issue:hover {
+    color: var(--status-accent);
+    transform: scale(1.15);
+}
+
+.feature-issue svg {
+    width: 100%;
+    height: 100%;
 }
 
 /* Floating page controls (modules) */
@@ -1683,6 +1963,14 @@ a.footer-link:hover {
 
 .snapshot-mode .column-todo .column-content {
     grid-template-columns: repeat(2, 1fr);
+}
+
+.snapshot-mode .card-body {
+    grid-template-rows: 1fr;
+}
+
+.snapshot-mode .card-chevron {
+    display: none;
 }
 
 /* ==========================================================================
@@ -1942,7 +2230,7 @@ a.footer-link:hover {
     }
 
     .comparison {
-        padding: 1.25rem;
+        padding: 0;
     }
 
     .footer-content {


### PR DESCRIPTION
The modules board drifted from the compiler: version tags now name published releases only, anything merged but unreleased is tagged `upcoming`, cards with pending items moved to In Progress, the Advanced Control Flow card was a duplicate of Control Flow and is gone, and Dynamic Module Loading is back to todo since imports link statically at compile time. Cards start collapsed and expand on click, the progress bar doubles as the divider under each card title, and items tracked by an open issue link straight to it.

The landing page now leads with a copyable `cargo add waspy` terminal window instead of the CTA buttons, and the code example lives below How It Works as a three-step flow (`fibonacci.py` -> `main.rs` -> `run.mjs`) with captions explaining what each step produces, plus small cards for the `compile_python_to_wasm` and `compile_python_project` entry points. The redundant Get Started section is gone and the comparison table sits directly in the section instead of inside a glass card. Also fixes the hero Rust snippet, where an unescaped `Box<dyn Error>` was being parsed as an HTML tag and swallowed.

AGENTS.md and CONTRIBUTING.md now record the convention: board version tags only ever name published releases, and `upcoming` tags are swapped for the real version at release time.