### PR TITLE
docs(site): add a contributors section and related projects

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -542,6 +542,34 @@ console.log(instance.exports.factorial(5));
             </div>
         </section>
 
+
+        <section class="section" id="contributors">
+            <div class="container">
+                <div class="section-header reveal">
+                    <span class="kicker">The people</span>
+                    <h2>Contributors</h2>
+                    <p class="section-subtitle">Waspy is built in the open by everyone who has sent a patch, an issue, or an idea.</p>
+                </div>
+
+                <div class="contributors-panel reveal">
+                    <div class="contributors-grid" id="contributorsGrid" aria-live="polite">
+                        <p class="contributors-status">Loading contributors from GitHub...</p>
+                    </div>
+                </div>
+
+                <div class="contribute-cta reveal">
+                    <h3>Wanna contribute to Waspy?</h3>
+                    <p>Waspy is free and open source under the MIT license, and it gets better every time someone new pokes at it. A compiler is a big surface: the parser, the IR, codegen, the runtime, the docs you are reading right now. There is room for a first commit at almost any level of experience.</p>
+                    <p>Pick up a good first issue, report a Python snippet that miscompiles, teach the compiler one more builtin, or just tell us what you tried to build and where it broke. Every one of those genuinely moves the project forward, and we would love to work on it together.</p>
+                    <div class="cta-buttons">
+                        <a href="https://github.com/anistark/waspy/blob/main/CONTRIBUTING.md" class="btn btn-primary">Read the contributing guide</a>
+                        <a href="https://github.com/anistark/waspy/issues" class="btn btn-secondary">Browse open issues</a>
+                        <a href="https://github.com/anistark/waspy/discussions" class="btn btn-secondary">Start a discussion</a>
+                    </div>
+                </div>
+            </div>
+        </section>
+
     </main>
 
     <footer class="site-footer">
@@ -554,11 +582,6 @@ console.log(instance.exports.factorial(5));
                         <a href="https://github.com/anistark/waspy" class="social-link" title="GitHub">
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                                 <path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
-                            </svg>
-                        </a>
-                        <a href="https://crates.io/crates/waspy" class="social-link" title="Crates.io">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 0L1.608 6v12L12 24l10.392-6V6L12 0zm-1.601 8.4l-2.4 1.385v2.77l2.4 1.385 2.4-1.385v-2.77L10.399 8.4zm3.601 0l-2.4 1.385v2.77l2.4 1.385 2.4-1.385v-2.77L14 8.4z"/>
                             </svg>
                         </a>
                         <a href="https://x.com/kranirudha" class="social-link" title="X (Twitter)">
@@ -588,15 +611,20 @@ console.log(instance.exports.factorial(5));
                     <a href="https://github.com/anistark/waspy/issues" class="footer-link">Issues</a>
                     <a href="https://github.com/anistark/waspy/discussions" class="footer-link">Discussions</a>
                     <a href="https://crates.io/crates/waspy" class="footer-link">Crates.io</a>
+                    <a href="https://docs.rs/waspy/latest/" class="footer-link">docs.rs</a>
                     <a href="https://github.com/anistark/waspy/releases" class="footer-link">Releases</a>
                 </div>
 
                 <div class="footer-section">
-                    <h3>Technology</h3>
-                    <span class="footer-link">Built with Rust 🦀</span>
-                    <span class="footer-link">WebAssembly Target</span>
-                    <span class="footer-link">RustPython Parser</span>
-                    <span class="footer-link">Binaryen Optimizer</span>
+                    <h3>Related</h3>
+                    <a href="https://github.com/anistark/wasmrun" class="footer-link related-link">
+                        <span class="related-name">wasmrun</span>
+                        <span class="related-desc">WASM runtime with debug capabilities</span>
+                    </a>
+                    <a href="https://anistark.github.io/wasmhub/" class="footer-link related-link">
+                        <span class="related-name">wasmhub</span>
+                        <span class="related-desc">Open source hub of WASM language runtimes</span>
+                    </a>
                 </div>
             </div>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -20,6 +20,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
 
+    loadContributors();
+
     document.querySelectorAll('.copy-btn[data-copy]').forEach(btn => {
         btn.addEventListener('click', () => {
             navigator.clipboard.writeText(btn.dataset.copy).then(() => {
@@ -34,3 +36,54 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 });
+
+function loadContributors() {
+    const grid = document.getElementById('contributorsGrid');
+    if (!grid) return;
+
+    const listUrl = 'https://github.com/anistark/waspy/graphs/contributors';
+
+    const fail = () => {
+        grid.innerHTML = '<p class="contributors-status">Could not load the list right now. ' +
+            '<a href="' + listUrl + '">See contributors on GitHub</a>.</p>';
+    };
+
+    fetch('https://api.github.com/repos/anistark/waspy/contributors?per_page=100')
+        .then(res => res.ok ? res.json() : Promise.reject(new Error(res.status)))
+        .then(people => {
+            const humans = people.filter(p =>
+                p.type !== 'Bot' && !/\[bot\]$/.test(p.login || '')
+            );
+
+            if (!humans.length) return fail();
+
+            grid.innerHTML = '';
+            humans.forEach(p => {
+                const a = document.createElement('a');
+                a.className = 'contributor';
+                a.href = p.html_url;
+                a.target = '_blank';
+                a.rel = 'noopener';
+                a.title = p.login + ': ' + p.contributions + ' commits';
+
+                const img = document.createElement('img');
+                img.src = p.avatar_url + '&s=140';
+                img.alt = p.login;
+                img.loading = 'lazy';
+                img.width = 64;
+                img.height = 64;
+
+                const name = document.createElement('span');
+                name.className = 'contributor-name';
+                name.textContent = p.login;
+
+                const count = document.createElement('span');
+                count.className = 'contributor-count';
+                count.textContent = p.contributions + (p.contributions === 1 ? ' commit' : ' commits');
+
+                a.append(img, name, count);
+                grid.appendChild(a);
+            });
+        })
+        .catch(fail);
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -1468,6 +1468,159 @@ tbody tr:hover td.col-waspy {
    Footer (shared)
    ========================================================================== */
 
+/* ==========================================================================
+   Contributors
+   ========================================================================== */
+
+.contributors-panel {
+    background: var(--bg-glass);
+    backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    border-radius: 20px;
+    box-shadow: inset 0 1px 0 var(--glass-highlight), var(--shadow-soft);
+    padding: 2rem;
+}
+
+.contributors-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+    gap: 1rem;
+}
+
+.contributors-status {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--text-2);
+    font-size: 0.9rem;
+    padding: 1rem 0;
+}
+
+.contributor {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 1.1rem 0.75rem;
+    border-radius: var(--radius);
+    border: 1px solid transparent;
+    text-decoration: none;
+    color: var(--text-1);
+    transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease, color 0.25s ease;
+}
+
+.contributor:hover {
+    transform: translateY(-4px);
+    color: var(--text-0);
+    border-color: color-mix(in srgb, var(--amber) 35%, var(--glass-border));
+    background: color-mix(in srgb, var(--amber) 7%, transparent);
+}
+
+.contributor img {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    border: 2px solid var(--glass-border);
+    background: var(--bg-1);
+    transition: border-color 0.25s ease;
+}
+
+.contributor:hover img {
+    border-color: var(--amber);
+}
+
+.contributor-name {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 600;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.contributor-count {
+    font-size: 0.7rem;
+    color: var(--text-2);
+}
+
+.contribute-cta {
+    margin-top: 2rem;
+    padding: 2.25rem 2.5rem;
+    border-radius: 20px;
+    background: var(--bg-glass);
+    backdrop-filter: blur(16px);
+    border: 1px solid var(--glass-border);
+    box-shadow: inset 0 1px 0 var(--glass-highlight), var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
+}
+
+.contribute-cta::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: var(--grad-warm);
+}
+
+.contribute-cta h3 {
+    font-family: var(--font-display);
+    font-size: 1.5rem;
+    margin-bottom: 0.9rem;
+    color: var(--text-0);
+}
+
+.contribute-cta p {
+    color: var(--text-1);
+    line-height: 1.7;
+    margin-bottom: 1rem;
+}
+
+.contribute-cta .cta-buttons {
+    margin-top: 1.5rem;
+}
+
+@media (max-width: 620px) {
+    .contributors-panel {
+        padding: 1.25rem;
+    }
+
+    .contributors-grid {
+        grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+        gap: 0.6rem;
+    }
+
+    .contributor img {
+        width: 52px;
+        height: 52px;
+    }
+
+    .contribute-cta {
+        padding: 1.5rem 1.35rem;
+    }
+}
+
+/* Footer related projects */
+
+.related-link {
+    padding: 0.4rem 0;
+}
+
+.related-name {
+    display: block;
+    font-family: var(--font-mono);
+    font-weight: 600;
+    color: inherit;
+}
+
+.related-desc {
+    display: block;
+    font-size: 0.78rem;
+    color: var(--text-2);
+    line-height: 1.4;
+    margin-top: 0.15rem;
+}
+
 .site-footer {
     border-top: 1px solid var(--glass-border);
     margin-top: 3rem;


### PR DESCRIPTION
The landing page now has a Contributors section under Architecture. It pulls the list from the GitHub API on load, filters out bots, and shows each person's avatar, handle, and commit count linking to their profile, falling back to a link to the contributors graph when the API is unreachable or rate limited. Below it a "Wanna contribute to Waspy?" panel points at `CONTRIBUTING.md`, open issues, and discussions.

In the footer, the Technology column is now Related and links to `wasmrun` and `wasmhub`, docs.rs sits under Crates.io in Community, and the crates.io and docs.rs icons are out of the social row.